### PR TITLE
Fix dependency issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To use this framework as part of your Maven build simply add the jcentral reposi
 <dependency>
   <groupId>com.dlsc.formsfx</groupId>
   <artifactId>formsfx-core</artifactId>
-  <version>1.0</version>
+  <version>1.1</version>
 </dependency>
 ```
 

--- a/formsfx-demo/pom.xml
+++ b/formsfx-demo/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>com.dlsc.formsfx</groupId>
             <artifactId>formsfx-core</artifactId>
-            <version>1.0</version>
+            <version>1.1</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
In `formsfx-demo/pom.xml`, the dependency still mentioned version 1.0, which made the build fail and caused the dependency not being able to be pulled from bintray. Hopefully this should fix it!