### PR TITLE
Additional description support for label/value

### DIFF
--- a/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleBooleanControl.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleBooleanControl.java
@@ -21,8 +21,11 @@ package com.dlsc.formsfx.view.controls;
  */
 
 import com.dlsc.formsfx.model.structure.BooleanField;
+import javafx.geometry.VPos;
+import javafx.scene.Node;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.Label;
+import javafx.scene.layout.GridPane;
 import javafx.scene.layout.VBox;
 
 /**
@@ -66,10 +69,22 @@ public class SimpleBooleanControl extends SimpleControl<BooleanField> {
     public void layoutParts() {
         super.layoutParts();
 
+        int columns = field.getSpan();
         container.getChildren().add(checkBox);
 
-        add(fieldLabel, 0,0,2,1);
-        add(container, 2, 0, field.getSpan() - 2,1);
+        Node labelDescription = field.getLabelDescription();
+        Node valueDescription = field.getValueDescription();
+
+        add(fieldLabel, 0, 0, 2, 1);
+        if (labelDescription != null) {
+            GridPane.setValignment(labelDescription, VPos.TOP);
+            add(labelDescription, 0, 1, 2, 1);
+        }
+        add(container, 2, 0, columns - 2, 1);
+        if (valueDescription != null) {
+            GridPane.setValignment(valueDescription, VPos.TOP);
+            add(valueDescription, 2, 1, columns - 2, 1);
+        }
     }
 
     /**

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleCheckBoxControl.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleCheckBoxControl.java
@@ -21,8 +21,11 @@ package com.dlsc.formsfx.view.controls;
  */
 
 import com.dlsc.formsfx.model.structure.MultiSelectionField;
+import javafx.geometry.VPos;
+import javafx.scene.Node;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.Label;
+import javafx.scene.layout.GridPane;
 import javafx.scene.layout.VBox;
 
 import java.util.ArrayList;
@@ -73,8 +76,19 @@ public class SimpleCheckBoxControl<V> extends SimpleControl<MultiSelectionField<
 
         box.setSpacing(5);
 
-        add(fieldLabel, 0,0,2,1);
-        add(box, 2, 0, columns - 2,1);
+        Node labelDescription = field.getLabelDescription();
+        Node valueDescription = field.getValueDescription();
+
+        add(fieldLabel, 0, 0, 2, 1);
+        if (labelDescription != null) {
+            GridPane.setValignment(labelDescription, VPos.TOP);
+            add(labelDescription, 0, 1, 2, 1);
+        }
+        add(box, 2, 0, columns - 2, 1);
+        if (valueDescription != null) {
+            GridPane.setValignment(valueDescription, VPos.TOP);
+            add(valueDescription, 2, 1, columns - 2, 1);
+        }
     }
 
     /**

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleComboBoxControl.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleComboBoxControl.java
@@ -22,8 +22,11 @@ package com.dlsc.formsfx.view.controls;
 
 import com.dlsc.formsfx.model.structure.SingleSelectionField;
 import javafx.geometry.Pos;
+import javafx.geometry.VPos;
+import javafx.scene.Node;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.Label;
+import javafx.scene.layout.GridPane;
 import javafx.scene.layout.StackPane;
 
 /**
@@ -82,8 +85,19 @@ public class SimpleComboBoxControl<V> extends SimpleControl<SingleSelectionField
         stack.setAlignment(Pos.CENTER_LEFT);
         stack.getChildren().addAll(comboBox, readOnlyLabel);
 
-        add(fieldLabel, 0,0,2,1);
+        Node labelDescription = field.getLabelDescription();
+        Node valueDescription = field.getValueDescription();
+
+        add(fieldLabel, 0, 0, 2, 1);
+        if (labelDescription != null) {
+            GridPane.setValignment(labelDescription, VPos.TOP);
+            add(labelDescription, 0, 1, 2, 1);
+        }
         add(stack, 2, 0, columns - 2, 1);
+        if (valueDescription != null) {
+            GridPane.setValignment(valueDescription, VPos.TOP);
+            add(valueDescription, 2, 1, columns - 2, 1);
+        }
     }
 
     /**

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleListViewControl.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleListViewControl.java
@@ -22,9 +22,12 @@ package com.dlsc.formsfx.view.controls;
 
 import com.dlsc.formsfx.model.structure.MultiSelectionField;
 import javafx.collections.ListChangeListener;
+import javafx.geometry.VPos;
+import javafx.scene.Node;
 import javafx.scene.control.Label;
 import javafx.scene.control.ListView;
 import javafx.scene.control.SelectionMode;
+import javafx.scene.layout.GridPane;
 
 /**
  * This class provides the base implementation for a simple control to edit
@@ -82,8 +85,19 @@ public class SimpleListViewControl<V> extends SimpleControl<MultiSelectionField<
 
         listView.setPrefHeight(200);
 
-        add(fieldLabel, 0,0,2,1);
+        Node labelDescription = field.getLabelDescription();
+        Node valueDescription = field.getValueDescription();
+
+        add(fieldLabel, 0, 0, 2, 1);
+        if (labelDescription != null) {
+            GridPane.setValignment(labelDescription, VPos.TOP);
+            add(labelDescription, 0, 1, 2, 1);
+        }
         add(listView, 2, 0, columns - 2, 1);
+        if (valueDescription != null) {
+            GridPane.setValignment(valueDescription, VPos.TOP);
+            add(valueDescription, 2, 1, columns - 2, 1);
+        }
     }
 
     /**

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleNumberControl.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleNumberControl.java
@@ -22,8 +22,11 @@ package com.dlsc.formsfx.view.controls;
 
 import com.dlsc.formsfx.model.structure.DataField;
 import javafx.geometry.Pos;
+import javafx.geometry.VPos;
+import javafx.scene.Node;
 import javafx.scene.control.Label;
 import javafx.scene.control.Spinner;
+import javafx.scene.layout.GridPane;
 import javafx.scene.layout.StackPane;
 
 /**
@@ -80,14 +83,34 @@ public abstract class SimpleNumberControl<F extends DataField, D extends Number>
 
         editableSpinner.setMaxWidth(Double.MAX_VALUE);
 
+        Node labelDescription = field.getLabelDescription();
+        Node valueDescription = field.getValueDescription();
+
         int columns = field.getSpan();
 
         if (columns < 3) {
-            add(fieldLabel, 0, 0, columns, 0);
-            add(stack, 0, 1, columns, 1);
+            int rowIndex = 0;
+            add(fieldLabel, 0, rowIndex++, columns, 1);
+            if (labelDescription != null) {
+                GridPane.setValignment(labelDescription, VPos.TOP);
+                add(labelDescription, 0, rowIndex++, columns, 1);
+            }
+            add(stack, 0, rowIndex++, columns, 1);
+            if (valueDescription != null) {
+                GridPane.setValignment(valueDescription, VPos.TOP);
+                add(valueDescription, 0, rowIndex, columns, 1);
+            }
         } else {
             add(fieldLabel, 0, 0, 2, 1);
+            if (labelDescription != null) {
+                GridPane.setValignment(labelDescription, VPos.TOP);
+                add(labelDescription, 0, 1, 2, 1);
+            }
             add(stack, 2, 0, columns - 2, 1);
+            if (valueDescription != null) {
+                GridPane.setValignment(valueDescription, VPos.TOP);
+                add(valueDescription, 2, 1, columns - 2, 1);
+            }
         }
     }
 

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimplePasswordControl.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimplePasswordControl.java
@@ -24,7 +24,10 @@ import com.dlsc.formsfx.model.structure.PasswordField;
 import javafx.beans.binding.Bindings;
 import javafx.beans.binding.StringBinding;
 import javafx.geometry.Pos;
+import javafx.geometry.VPos;
+import javafx.scene.Node;
 import javafx.scene.control.Label;
+import javafx.scene.layout.GridPane;
 import javafx.scene.layout.StackPane;
 
 /**
@@ -93,14 +96,34 @@ public class SimplePasswordControl extends SimpleControl<PasswordField> {
 
         stack.setAlignment(Pos.CENTER_LEFT);
 
+        Node labelDescription = field.getLabelDescription();
+        Node valueDescription = field.getValueDescription();
+
         int columns = field.getSpan();
 
         if (columns < 3) {
-            add(fieldLabel, 0, 0, columns, 1);
-            add(stack, 0, 1, columns, 1);
+            int rowIndex = 0;
+            add(fieldLabel, 0, rowIndex++, columns, 1);
+            if (labelDescription != null) {
+                GridPane.setValignment(labelDescription, VPos.TOP);
+                add(labelDescription, 0, rowIndex++, columns, 1);
+            }
+            add(stack, 0, rowIndex++, columns, 1);
+            if (valueDescription != null) {
+                GridPane.setValignment(valueDescription, VPos.TOP);
+                add(valueDescription, 0, rowIndex, columns, 1);
+            }
         } else {
             add(fieldLabel, 0, 0, 2, 1);
+            if (labelDescription != null) {
+                GridPane.setValignment(labelDescription, VPos.TOP);
+                add(labelDescription, 0, 1, 2, 1);
+            }
             add(stack, 2, 0, columns - 2, 1);
+            if (valueDescription != null) {
+                GridPane.setValignment(valueDescription, VPos.TOP);
+                add(valueDescription, 2, 1, columns - 2, 1);
+            }
         }
     }
 

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleRadioButtonControl.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleRadioButtonControl.java
@@ -21,9 +21,12 @@ package com.dlsc.formsfx.view.controls;
  */
 
 import com.dlsc.formsfx.model.structure.SingleSelectionField;
+import javafx.geometry.VPos;
+import javafx.scene.Node;
 import javafx.scene.control.Label;
 import javafx.scene.control.RadioButton;
 import javafx.scene.control.ToggleGroup;
+import javafx.scene.layout.GridPane;
 import javafx.scene.layout.VBox;
 
 import java.util.ArrayList;
@@ -77,8 +80,19 @@ public class SimpleRadioButtonControl<V> extends SimpleControl<SingleSelectionFi
 
         box.setSpacing(5);
 
-        add(fieldLabel, 0,0,2,1);
-        add(box, 2, 0, columns - 2,1);
+        Node labelDescription = field.getLabelDescription();
+        Node valueDescription = field.getValueDescription();
+
+        add(fieldLabel, 0, 0, 2, 1);
+        if (labelDescription != null) {
+            GridPane.setValignment(labelDescription, VPos.TOP);
+            add(labelDescription, 0, 1, 2, 1);
+        }
+        add(box, 2, 0, columns - 2, 1);
+        if (valueDescription != null) {
+            GridPane.setValignment(valueDescription, VPos.TOP);
+            add(valueDescription, 2, 1, columns - 2, 1);
+        }
     }
 
     /**

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleTextControl.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleTextControl.java
@@ -23,9 +23,12 @@ package com.dlsc.formsfx.view.controls;
 import com.dlsc.formsfx.model.structure.StringField;
 import javafx.beans.binding.Bindings;
 import javafx.geometry.Pos;
+import javafx.geometry.VPos;
+import javafx.scene.Node;
 import javafx.scene.control.Label;
 import javafx.scene.control.TextArea;
 import javafx.scene.control.TextField;
+import javafx.scene.layout.GridPane;
 import javafx.scene.layout.StackPane;
 
 /**
@@ -99,14 +102,34 @@ public class SimpleTextControl extends SimpleControl<StringField> {
 
         stack.setAlignment(Pos.CENTER_LEFT);
 
+        Node labelDescription = field.getLabelDescription();
+        Node valueDescription = field.getValueDescription();
+
         int columns = field.getSpan();
 
         if (columns < 3) {
-            add(fieldLabel, 0, 0, columns, 1);
-            add(stack, 0, 1, columns, 1);
+            int rowIndex = 0;
+            add(fieldLabel, 0, rowIndex++, columns, 1);
+            if (labelDescription != null) {
+                GridPane.setValignment(labelDescription, VPos.TOP);
+                add(labelDescription, 0, rowIndex++, columns, 1);
+            }
+            add(stack, 0, rowIndex++, columns, 1);
+            if (valueDescription != null) {
+                GridPane.setValignment(valueDescription, VPos.TOP);
+                add(valueDescription, 0, rowIndex, columns, 1);
+            }
         } else {
             add(fieldLabel, 0, 0, 2, 1);
+            if (labelDescription != null) {
+                GridPane.setValignment(labelDescription, VPos.TOP);
+                add(labelDescription, 0, 1, 2, 1);
+            }
             add(stack, 2, 0, columns - 2, 1);
+            if (valueDescription != null) {
+                GridPane.setValignment(valueDescription, VPos.TOP);
+                add(valueDescription, 2, 1, columns - 2, 1);
+            }
         }
     }
 

--- a/formsfx-demo/src/main/resources/style.css
+++ b/formsfx-demo/src/main/resources/style.css
@@ -2,7 +2,10 @@
     font-family: 'Flaticon';
     src: url(/flaticon.ttf);
 }
-
+.field-label-description,
+.field-value-description {
+    -fx-text-fill: red;
+}
 .root-pane {
     -fx-padding: 0;
     -fx-font-family: 'Arial';


### PR DESCRIPTION
Fix for #18.

Some implementation details:
- additional descriptions are set as `Node` fields instead of `ObjectProperty<Node>` to keep layout logic simple.
- both `labelDescription` and `valueDescription` are I18N aware.
- `String` values are automatically wrapped with `Label`.
- an extra CSS style class is added to the supplied `Node`s.