### PR TITLE
Add event handlers to Form/Group/Field

### DIFF
--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/event/FieldEvent.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/event/FieldEvent.java
@@ -1,0 +1,67 @@
+package com.dlsc.formsfx.model.event;
+
+/*-
+ * ========================LICENSE_START=================================
+ * FormsFX
+ * %%
+ * Copyright (C) 2017 - 2018 DLSC Software & Consulting
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import com.dlsc.formsfx.model.structure.Field;
+import javafx.event.Event;
+import javafx.event.EventType;
+
+/**
+ * Identifies events triggered by a {@code Field}.
+ *
+ * @author Andres Almiray
+ */
+public final class FieldEvent extends Event {
+    /**
+     * When a {@code Field} is persisted.
+     */
+    public static final EventType<FieldEvent> EVENT_FIELD_PERSISTED = new EventType<>(ANY, "EVENT_FIELD_PERSISTED");
+
+    /**
+     * When a {@code Field} is reset.
+     */
+    public static final EventType<FieldEvent> EVENT_FIELD_RESET = new EventType<>(ANY, "EVENT_FIELD_RESET");
+
+    /**
+     * Creates a new instance of {@code FieldEvent} with event type set to {@code EVENT_FIELD_PERSISTED}.
+     */
+    public static FieldEvent fieldPersistedEvent(Field field) {
+        return new FieldEvent(EVENT_FIELD_PERSISTED, field);
+    }
+
+    /**
+     * Creates a new instance of {@code FieldEvent} with event type set to {@code EVENT_FIELD_RESET}.
+     */
+    public static FieldEvent fieldResetEvent(Field field) {
+        return new FieldEvent(EVENT_FIELD_RESET, field);
+    }
+
+    private final Field field;
+
+    private FieldEvent(EventType<? extends Event> eventType, Field field) {
+        super(eventType);
+        this.field = field;
+    }
+
+    public final Field getField() {
+        return field;
+    }
+}

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/event/FormEvent.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/event/FormEvent.java
@@ -1,0 +1,67 @@
+package com.dlsc.formsfx.model.event;
+
+/*-
+ * ========================LICENSE_START=================================
+ * FormsFX
+ * %%
+ * Copyright (C) 2017 - 2018 DLSC Software & Consulting
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import com.dlsc.formsfx.model.structure.Form;
+import javafx.event.Event;
+import javafx.event.EventType;
+
+/**
+ * Identifies events triggered by a {@code Form}.
+ *
+ * @author Andres Almiray
+ */
+public final class FormEvent extends Event {
+    /**
+     * When a {@code Form} is persisted.
+     */
+    public static final EventType<FormEvent> EVENT_FORM_PERSISTED = new EventType<>(ANY, "EVENT_FORM_PERSISTED");
+
+    /**
+     * When a {@code Form} is reset.
+     */
+    public static final EventType<FormEvent> EVENT_FORM_RESET = new EventType<>(ANY, "EVENT_FORM_RESET");
+
+    /**
+     * Creates a new instance of {@code FormEvent} with event type set to {@code EVENT_FORM_PERSISTED}.
+     */
+    public static FormEvent formPersistedEvent(Form form) {
+        return new FormEvent(EVENT_FORM_PERSISTED, form);
+    }
+
+    /**
+     * Creates a new instance of {@code FormEvent} with event type set to {@code EVENT_FORM_RESET}.
+     */
+    public static FormEvent formResetEvent(Form form) {
+        return new FormEvent(EVENT_FORM_RESET, form);
+    }
+
+    private final Form form;
+
+    private FormEvent(EventType<? extends Event> eventType, Form form) {
+        super(eventType);
+        this.form = form;
+    }
+
+    public final Form getForm() {
+        return form;
+    }
+}

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/event/GroupEvent.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/event/GroupEvent.java
@@ -1,0 +1,67 @@
+package com.dlsc.formsfx.model.event;
+
+/*-
+ * ========================LICENSE_START=================================
+ * FormsFX
+ * %%
+ * Copyright (C) 2017 - 2018 DLSC Software & Consulting
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import com.dlsc.formsfx.model.structure.Group;
+import javafx.event.Event;
+import javafx.event.EventType;
+
+/**
+ * Identifies events triggered by a {@code Group}.
+ *
+ * @author Andres Almiray
+ */
+public final class GroupEvent extends Event {
+    /**
+     * When a {@code Group} is persisted.
+     */
+    public static final EventType<GroupEvent> EVENT_GROUP_PERSISTED = new EventType<>(ANY, "EVENT_GROUP_PERSISTED");
+
+    /**
+     * When a {@code Group} is reset.
+     */
+    public static final EventType<GroupEvent> EVENT_GROUP_RESET = new EventType<>(ANY, "EVENT_GROUP_RESET");
+
+    /**
+     * Creates a new instance of {@code GroupEvent} with event type set to {@code EVENT_GROUP_PERSISTED}.
+     */
+    public static GroupEvent groupPersistedEvent(Group group) {
+        return new GroupEvent(EVENT_GROUP_PERSISTED, group);
+    }
+
+    /**
+     * Creates a new instance of {@code GroupEvent} with event type set to {@code EVENT_GROUP_RESET}.
+     */
+    public static GroupEvent groupResetEvent(Group group) {
+        return new GroupEvent(EVENT_GROUP_RESET, group);
+    }
+
+    private final Group group;
+
+    private GroupEvent(EventType<? extends Event> eventType, Group group) {
+        super(eventType);
+        this.group = group;
+    }
+
+    public final Group getGroup() {
+        return group;
+    }
+}

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/DataField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/DataField.java
@@ -20,6 +20,7 @@ package com.dlsc.formsfx.model.structure;
  * =========================LICENSE_END==================================
  */
 
+import com.dlsc.formsfx.model.event.FieldEvent;
 import com.dlsc.formsfx.model.util.BindingMode;
 import com.dlsc.formsfx.model.util.TranslationService;
 import com.dlsc.formsfx.model.util.ValueTransformer;
@@ -262,6 +263,8 @@ public class DataField<P extends Property, V, F extends Field> extends Field<F> 
         }
 
         persistentValue.setValue(value.getValue());
+
+        fireEvent(FieldEvent.fieldPersistedEvent(this));
     }
 
     /**
@@ -274,6 +277,8 @@ public class DataField<P extends Property, V, F extends Field> extends Field<F> 
         }
 
         userInput.setValue(String.valueOf(persistentValue.getValue()));
+
+        fireEvent(FieldEvent.fieldResetEvent(this));
     }
 
     /**

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/Group.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/Group.java
@@ -21,13 +21,19 @@ package com.dlsc.formsfx.model.structure;
  */
 
 
+import com.dlsc.formsfx.model.event.GroupEvent;
 import com.dlsc.formsfx.model.util.TranslationService;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
+import javafx.event.EventHandler;
+import javafx.event.EventType;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * A group is the intermediate unit in a form. It is used to group form
@@ -53,6 +59,8 @@ public class Group {
      * is used to translate all translatable values of the field.
      */
     protected TranslationService translationService;
+
+    private final Map<EventType<GroupEvent>,List<EventHandler<? super GroupEvent>>> eventHandlers = new ConcurrentHashMap<>();
 
     /**
      * Internal constructor for the {@code Group} class. To create new
@@ -123,6 +131,8 @@ public class Group {
         }
 
         fields.forEach(Field::persist);
+
+        fireEvent(GroupEvent.groupPersistedEvent(this));
     }
 
     /**
@@ -135,6 +145,8 @@ public class Group {
         }
 
         fields.forEach(Field::reset);
+
+        fireEvent(GroupEvent.groupResetEvent(this));
     }
 
     /**
@@ -177,4 +189,65 @@ public class Group {
         return translationService != null;
     }
 
+    /**
+     * Registers an event handler to this group. The handler is called when the
+     * group receives an {@code Event} of the specified type during the bubbling
+     * phase of event delivery.
+     *
+     * @param eventType    the type of the events to receive by the handler
+     * @param eventHandler the handler to register
+     *
+     * @throws NullPointerException if either event type or handler are {@code null}.
+     */
+    public Group addEventHandler(EventType<GroupEvent> eventType, EventHandler<? super GroupEvent> eventHandler) {
+        if (eventType == null) {
+            throw new NullPointerException("Argument eventType must not be null");
+        }
+        if (eventHandler == null) {
+            throw new NullPointerException("Argument eventHandler must not be null");
+        }
+
+        this.eventHandlers.computeIfAbsent(eventType, k -> new CopyOnWriteArrayList<>()).add(eventHandler);
+
+        return this;
+    }
+
+    /**
+     * Unregisters a previously registered event handler from this group. One
+     * handler might have been registered for different event types, so the
+     * caller needs to specify the particular event type from which to
+     * unregister the handler.
+     *
+     * @param eventType    the event type from which to unregister
+     * @param eventHandler the handler to unregister
+     *
+     * @throws NullPointerException if either event type or handler are {@code null}.
+     */
+    public Group removeEventHandler(EventType<GroupEvent> eventType, EventHandler<? super GroupEvent> eventHandler) {
+        if (eventType == null) {
+            throw new NullPointerException("Argument eventType must not be null");
+        }
+        if (eventHandler == null) {
+            throw new NullPointerException("Argument eventHandler must not be null");
+        }
+
+        List<EventHandler<? super GroupEvent>> list = this.eventHandlers.get(eventType);
+        if (list != null) {
+            list.remove(eventHandler);
+        }
+
+        return this;
+    }
+
+    protected void fireEvent(GroupEvent event) {
+        List<EventHandler<? super GroupEvent>> list = this.eventHandlers.get(event.getEventType());
+        if (list == null) {
+            return;
+        }
+        for (EventHandler<? super GroupEvent> eventHandler : list) {
+            if (!event.isConsumed()) {
+                eventHandler.handle(event);
+            }
+        }
+    }
 }

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/MultiSelectionField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/MultiSelectionField.java
@@ -20,6 +20,7 @@ package com.dlsc.formsfx.model.structure;
  * =========================LICENSE_END==================================
  */
 
+import com.dlsc.formsfx.model.event.FieldEvent;
 import com.dlsc.formsfx.model.util.BindingMode;
 import com.dlsc.formsfx.model.validators.ValidationResult;
 import com.dlsc.formsfx.model.validators.Validator;
@@ -245,6 +246,8 @@ public class MultiSelectionField<V> extends SelectionField<V, MultiSelectionFiel
         }
 
         persistentSelection.setAll(selection.getValue());
+
+        fireEvent(FieldEvent.fieldPersistedEvent(this));
     }
 
     /**
@@ -257,6 +260,8 @@ public class MultiSelectionField<V> extends SelectionField<V, MultiSelectionFiel
         }
 
         selection.setAll(persistentSelection.getValue());
+
+        fireEvent(FieldEvent.fieldResetEvent(this));
     }
 
     /**

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/SingleSelectionField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/SingleSelectionField.java
@@ -20,6 +20,7 @@ package com.dlsc.formsfx.model.structure;
  * =========================LICENSE_END==================================
  */
 
+import com.dlsc.formsfx.model.event.FieldEvent;
 import com.dlsc.formsfx.model.util.BindingMode;
 import com.dlsc.formsfx.model.validators.ValidationResult;
 import com.dlsc.formsfx.model.validators.Validator;
@@ -242,6 +243,8 @@ public class SingleSelectionField<V> extends SelectionField<V, SingleSelectionFi
         }
 
         persistentSelection.setValue(selection.getValue());
+
+        fireEvent(FieldEvent.fieldPersistedEvent(this));
     }
 
     /**
@@ -254,6 +257,8 @@ public class SingleSelectionField<V> extends SelectionField<V, SingleSelectionFi
         }
 
         selection.setValue(persistentSelection.getValue());
+
+        fireEvent(FieldEvent.fieldResetEvent(this));
     }
 
     /**


### PR DESCRIPTION
Fix for #25 

Originally just wanted events to be applied to `Form` but it makes sense to be consistent with `Group` and `field` too.

Event handler registration follows the same rules as JavaFX `Node`, that is, it'll throw NPE if any of the passed in arguments is `null`. 