### PR TITLE
Extension points

### DIFF
--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/BooleanField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/BooleanField.java
@@ -43,7 +43,7 @@ public class BooleanField extends DataField<BooleanProperty, Boolean, BooleanFie
      *              The property that is used to store the latest persisted
      *              value of the field.
      */
-    BooleanField(SimpleBooleanProperty valueProperty, SimpleBooleanProperty persistentValueProperty) {
+    protected BooleanField(SimpleBooleanProperty valueProperty, SimpleBooleanProperty persistentValueProperty) {
         super(valueProperty, persistentValueProperty);
 
         valueTransformer = Boolean::parseBoolean;

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/DataField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/DataField.java
@@ -43,7 +43,7 @@ import java.util.stream.Collectors;
  * @author Sacha Schmid
  * @author Rinesch Murugathas
  */
-public class DataField<P extends Property, V, F extends Field> extends Field<F> {
+public abstract class DataField<P extends Property, V, F extends Field> extends Field<F> {
 
     /**
      * Every field tracks its value in multiple ways.
@@ -57,21 +57,21 @@ public class DataField<P extends Property, V, F extends Field> extends Field<F> 
      *   is the responsibility of the form creator to persist the field values
      *   at the correct time.
      */
-    final P value;
-    private final P persistentValue;
-    final StringProperty userInput = new SimpleStringProperty("");
+    protected final P value;
+    protected final P persistentValue;
+    protected final StringProperty userInput = new SimpleStringProperty("");
 
     /**
      * Every field contains a list of validators. The validators are limited to
      * the ones that correspond to the field's type.
      */
-    private final List<Validator<V>> validators = new ArrayList<>();
+    protected final List<Validator<V>> validators = new ArrayList<>();
 
     /**
      * The value transformer is responsible for transforming the user input
      * string to the specific type of the field's value.
      */
-    ValueTransformer<V> valueTransformer;
+    protected ValueTransformer<V> valueTransformer;
 
     /**
      * The format error is displayed when the value transformation fails.
@@ -79,13 +79,13 @@ public class DataField<P extends Property, V, F extends Field> extends Field<F> 
      * This property is translatable if a {@link TranslationService} is set on
      * the containing form.
      */
-    private final StringProperty formatErrorKey = new SimpleStringProperty("");
-    private final StringProperty formatError = new SimpleStringProperty("");
+    protected final StringProperty formatErrorKey = new SimpleStringProperty("");
+    protected final StringProperty formatError = new SimpleStringProperty("");
 
     /**
      * This listener updates the field when the external binding changes.
      */
-    private final InvalidationListener externalBindingListener = (observable) -> userInput.setValue(((P) observable).getValue().toString());
+    protected final InvalidationListener externalBindingListener = (observable) -> userInput.setValue(((P) observable).getValue().toString());
 
     /**
      * Internal constructor for the {@code DataField} class. To create new
@@ -103,7 +103,7 @@ public class DataField<P extends Property, V, F extends Field> extends Field<F> 
      *              The property that is used to store the latest persisted
      *              value of the field.
      */
-    DataField(P valueProperty, P persistentValueProperty) {
+    protected DataField(P valueProperty, P persistentValueProperty) {
         value = valueProperty;
         persistentValue = persistentValueProperty;
 
@@ -256,7 +256,7 @@ public class DataField<P extends Property, V, F extends Field> extends Field<F> 
      * Stores the field's current value in its persistent value. This stores
      * the user's changes in the model.
      */
-    void persist() {
+    public void persist() {
         if (!isValid()) {
             return;
         }
@@ -268,7 +268,7 @@ public class DataField<P extends Property, V, F extends Field> extends Field<F> 
      * Sets the field's current value to its persistent value, thus resetting
      * any changes made by the user.
      */
-    void reset() {
+    public void reset() {
         if (!hasChanged()) {
             return;
         }
@@ -295,7 +295,7 @@ public class DataField<P extends Property, V, F extends Field> extends Field<F> 
      *
      * @return Returns whether the user input is a valid value or not.
      */
-    boolean validate() {
+    public boolean validate() {
         String newValue = userInput.getValue();
 
         if (!validateRequired(newValue)) {

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/DoubleField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/DoubleField.java
@@ -43,7 +43,7 @@ public class DoubleField extends DataField<DoubleProperty, Double, DoubleField> 
      *              The property that is used to store the latest persisted
      *              value of the field.
      */
-    DoubleField(SimpleDoubleProperty valueProperty, SimpleDoubleProperty persistentValueProperty) {
+    protected DoubleField(SimpleDoubleProperty valueProperty, SimpleDoubleProperty persistentValueProperty) {
         super(valueProperty, persistentValueProperty);
 
         valueTransformer = Double::parseDouble;

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/Field.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/Field.java
@@ -64,8 +64,8 @@ public abstract class Field<F extends Field> {
      * This property is translatable if a {@link TranslationService} is set on
      * the containing form.
      */
-    private final StringProperty label = new SimpleStringProperty("");
-    private final StringProperty labelKey = new SimpleStringProperty("");
+    protected final StringProperty label = new SimpleStringProperty("");
+    protected final StringProperty labelKey = new SimpleStringProperty("");
 
     /**
      * The tooltip is an extension of the label. It contains additional
@@ -74,8 +74,8 @@ public abstract class Field<F extends Field> {
      * This property is translatable if a {@link TranslationService} is set on
      * the containing form.
      */
-    private final StringProperty tooltip = new SimpleStringProperty("");
-    private final StringProperty tooltipKey = new SimpleStringProperty("");
+    protected final StringProperty tooltip = new SimpleStringProperty("");
+    protected final StringProperty tooltipKey = new SimpleStringProperty("");
 
     /**
      * The placeholder is only visible in an empty field. It provides a hint to
@@ -84,31 +84,31 @@ public abstract class Field<F extends Field> {
      * This property is translatable if a {@link TranslationService} is set on
      * the containing form.
      */
-    private final StringProperty placeholder = new SimpleStringProperty("");
-    private final StringProperty placeholderKey = new SimpleStringProperty("");
+    protected final StringProperty placeholder = new SimpleStringProperty("");
+    protected final StringProperty placeholderKey = new SimpleStringProperty("");
 
     /**
      * Every field can be marked as {@code required} and {@code editable}. These
      * properties can change the field's behaviour.
      */
-    final StringProperty requiredErrorKey = new SimpleStringProperty("");
-    final StringProperty requiredError = new SimpleStringProperty("");
-    private final BooleanProperty required = new SimpleBooleanProperty(false);
-    private final BooleanProperty editable = new SimpleBooleanProperty(true);
+    protected final StringProperty requiredErrorKey = new SimpleStringProperty("");
+    protected final StringProperty requiredError = new SimpleStringProperty("");
+    protected final BooleanProperty required = new SimpleBooleanProperty(false);
+    protected final BooleanProperty editable = new SimpleBooleanProperty(true);
 
     /**
      * The field's current state is represented by the value properties, as
      * well as by the {@code valid} and {@code changed} flags.
      */
-    final BooleanProperty valid = new SimpleBooleanProperty(true);
-    final BooleanProperty changed = new SimpleBooleanProperty(false);
+    protected final BooleanProperty valid = new SimpleBooleanProperty(true);
+    protected final BooleanProperty changed = new SimpleBooleanProperty(false);
 
     /**
      * Fields can be styled using CSS through ID or class hooks.
      */
-    private final StringProperty id = new SimpleStringProperty(UUID.randomUUID().toString());
-    private final ListProperty<String> styleClass = new SimpleListProperty<>(FXCollections.observableArrayList());
-    private final IntegerProperty span = new SimpleIntegerProperty(12);
+    protected final StringProperty id = new SimpleStringProperty(UUID.randomUUID().toString());
+    protected final ListProperty<String> styleClass = new SimpleListProperty<>(FXCollections.observableArrayList());
+    protected final IntegerProperty span = new SimpleIntegerProperty(12);
 
     /**
      * The results of the field's validation is stored in this property. After
@@ -117,22 +117,22 @@ public abstract class Field<F extends Field> {
      * This property is translatable if a {@link TranslationService} is set on
      * the containing form.
      */
-    final ListProperty<String> errorMessages = new SimpleListProperty<>(FXCollections.observableArrayList());
-    final ListProperty<String> errorMessageKeys = new SimpleListProperty<>(FXCollections.observableArrayList());
+    protected final ListProperty<String> errorMessages = new SimpleListProperty<>(FXCollections.observableArrayList());
+    protected final ListProperty<String> errorMessageKeys = new SimpleListProperty<>(FXCollections.observableArrayList());
 
     /**
      * The translation service is passed down from the containing section. It
      * is used to translate all translatable values of the field.
      */
-    TranslationService translationService;
+    protected TranslationService translationService;
 
-    SimpleControl<F> renderer;
+    protected SimpleControl<F> renderer;
 
     /**
      * With the continuous binding mode, values are always directly persisted
      * upon any changes.
      */
-    final InvalidationListener bindingModeListener = (observable) -> {
+    protected final InvalidationListener bindingModeListener = (observable) -> {
         if (validate()) {
             persist();
         }
@@ -149,7 +149,7 @@ public abstract class Field<F extends Field> {
      * @see Field::ofMultiSelectionType
      * @see Field::ofSingleSelectionType
      */
-    Field() {
+    protected Field() {
 
         // Whenever one of the translatable fields' keys change, update the
         // displayed value based on the new translation.
@@ -565,11 +565,11 @@ public abstract class Field<F extends Field> {
      * @param newValue
      *              The new binding mode for the current field.
      */
-    abstract void setBindingMode(BindingMode newValue);
+    public abstract void setBindingMode(BindingMode newValue);
 
-    abstract void persist();
+    public abstract void persist();
 
-    abstract void reset();
+    public abstract void reset();
 
     /**
      * This internal method is called by the containing section when a new
@@ -604,7 +604,7 @@ public abstract class Field<F extends Field> {
      * @param keyProperty
      *              The internal property that holds the translation key.
      */
-    void updateElement(StringProperty displayProperty, StringProperty keyProperty) {
+    protected void updateElement(StringProperty displayProperty, StringProperty keyProperty) {
 
         // If the key has not yet been set that means that the translation
         // service was added for the first time. We can simply set the key
@@ -625,7 +625,7 @@ public abstract class Field<F extends Field> {
      *
      * @return Returns whether the user input is a valid value or not.
      */
-    abstract boolean validate();
+    protected abstract boolean validate();
 
     public String getPlaceholder() {
         return placeholder.get();

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/Form.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/Form.java
@@ -44,23 +44,23 @@ import java.util.stream.Collectors;
  */
 public class Form {
 
-    private final List<Group> groups = new ArrayList<>();
+    protected final List<Group> groups = new ArrayList<>();
 
     /**
      * The title acts as a description for the form.
      *
      * This property is translatable if a {@link TranslationService} is set.
      */
-    private final StringProperty title = new SimpleStringProperty("");
-    private final StringProperty titleKey = new SimpleStringProperty("");
+    protected final StringProperty title = new SimpleStringProperty("");
+    protected final StringProperty titleKey = new SimpleStringProperty("");
 
     /**
      * The form acts as a proxy for its contained sections' {@code changed}
      * and {@code valid} properties.
      */
-    private final BooleanProperty valid = new SimpleBooleanProperty(true);
-    private final BooleanProperty changed = new SimpleBooleanProperty(false);
-    private final BooleanProperty persistable = new SimpleBooleanProperty(false);
+    protected final BooleanProperty valid = new SimpleBooleanProperty(true);
+    protected final BooleanProperty changed = new SimpleBooleanProperty(false);
+    protected final BooleanProperty persistable = new SimpleBooleanProperty(false);
 
     /**
      * A form can optionally have a translation service. This service is used to
@@ -69,8 +69,8 @@ public class Form {
      *
      * @see TranslationService
      */
-    private final ObjectProperty<TranslationService> translationService = new SimpleObjectProperty<>();
-    private final Runnable localeChangeListener = this::translate;
+    protected final ObjectProperty<TranslationService> translationService = new SimpleObjectProperty<>();
+    protected final Runnable localeChangeListener = this::translate;
 
     /**
      * Internal constructor for the {@code Form} class. To create new
@@ -184,7 +184,7 @@ public class Form {
      *
      * @see Group::translate
      */
-    private void translate() {
+    protected void translate() {
         TranslationService tr = translationService.get();
 
         if (!isI18N()) {
@@ -230,7 +230,7 @@ public class Form {
      * Sets this form's {@code changed} property based on its contained
      * groups' changed properties.
      */
-    private void setChangedProperty() {
+    protected void setChangedProperty() {
         changed.setValue(groups.stream().anyMatch(Group::hasChanged));
         setPersistableProperty();
     }
@@ -239,7 +239,7 @@ public class Form {
      * Sets this form's {@code valid} property based on its contained groups'
      * changed properties.
      */
-    private void setValidProperty() {
+    protected void setValidProperty() {
         valid.setValue(groups.stream().allMatch(Group::isValid));
         setPersistableProperty();
     }
@@ -248,7 +248,7 @@ public class Form {
      * Sets this form's {@code persistable} property based on its contained
      * groups' persistable properties.
      */
-    private void setPersistableProperty() {
+    protected void setPersistableProperty() {
         persistable.setValue(groups.stream().anyMatch(Group::hasChanged) && groups.stream().allMatch(Group::isValid));
     }
 

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/Group.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/Group.java
@@ -45,8 +45,8 @@ public class Group {
      * The group acts as a proxy for its contained fields' {@code changed}
      * and {@code valid} properties.
      */
-    private final BooleanProperty valid = new SimpleBooleanProperty(true);
-    private final BooleanProperty changed = new SimpleBooleanProperty(false);
+    protected final BooleanProperty valid = new SimpleBooleanProperty(true);
+    protected final BooleanProperty changed = new SimpleBooleanProperty(false);
 
     /**
      * The translation service is passed down from the containing form. It
@@ -103,7 +103,7 @@ public class Group {
      * @param newValue
      *              The new service to use for translating translatable values.
      */
-    void translate(TranslationService newValue) {
+    protected void translate(TranslationService newValue) {
         translationService = newValue;
 
         if (!isI18N()) {
@@ -117,7 +117,7 @@ public class Group {
      * Persists the values for all contained fields.
      * @see Field::persist
      */
-    void persist() {
+    public void persist() {
         if (!isValid()) {
             return;
         }
@@ -129,7 +129,7 @@ public class Group {
      * Resets the values for all contained fields.
      * @see Field::reset
      */
-    void reset() {
+    public void reset() {
         if (!hasChanged()) {
             return;
         }
@@ -141,7 +141,7 @@ public class Group {
      * Sets this group's {@code changed} property based on its contained
      * fields' changed properties.
      */
-    private void setChangedProperty() {
+    protected void setChangedProperty() {
         changed.setValue(fields.stream().anyMatch(Field::hasChanged));
     }
 
@@ -149,7 +149,7 @@ public class Group {
      * Sets this group's {@code valid} property based on its contained fields'
      * changed properties.
      */
-    private void setValidProperty() {
+    protected void setValidProperty() {
         valid.setValue(fields.stream().allMatch(Field::isValid));
     }
 

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/IntegerField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/IntegerField.java
@@ -44,7 +44,7 @@ public class IntegerField extends DataField<IntegerProperty, Integer, IntegerFie
      *              The property that is used to store the latest persisted
      *              value of the field.
      */
-    IntegerField(SimpleIntegerProperty valueProperty, SimpleIntegerProperty persistentValueProperty) {
+    protected IntegerField(SimpleIntegerProperty valueProperty, SimpleIntegerProperty persistentValueProperty) {
         super(valueProperty, persistentValueProperty);
 
         valueTransformer = Integer::parseInt;

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/MultiSelectionField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/MultiSelectionField.java
@@ -47,14 +47,14 @@ public class MultiSelectionField<V> extends SelectionField<V, MultiSelectionFiel
      * A {@code MultiSelectionField} can have multiple items selected. These
      * items are stored in a {@code ListProperty}.
      */
-    private final ListProperty<V> persistentSelection = new SimpleListProperty<>(FXCollections.observableArrayList());
-    private final ListProperty<V> selection = new SimpleListProperty<>(FXCollections.observableArrayList());
+    protected final ListProperty<V> persistentSelection = new SimpleListProperty<>(FXCollections.observableArrayList());
+    protected final ListProperty<V> selection = new SimpleListProperty<>(FXCollections.observableArrayList());
 
     /**
      * Every field contains a list of validators. The validators are limited to
      * the ones that correspond to the field's type.
      */
-    private final List<Validator<ObservableList<V>>> validators = new ArrayList<>();
+    protected final List<Validator<ObservableList<V>>> validators = new ArrayList<>();
 
     /**
      * The constructor of {@code MultiSelectionField}.
@@ -64,7 +64,7 @@ public class MultiSelectionField<V> extends SelectionField<V, MultiSelectionFiel
      * @param selection
      *              The list of indices of items that are to be selected.
      */
-    MultiSelectionField(ListProperty<V> items, List<Integer> selection) {
+    protected MultiSelectionField(ListProperty<V> items, List<Integer> selection) {
         super(items);
 
         // Add items to the selection, based on their indices. This also
@@ -239,7 +239,7 @@ public class MultiSelectionField<V> extends SelectionField<V, MultiSelectionFiel
      * Stores the field's current selection in its persistent selection. This
      * stores the user's changes in the model.
      */
-    void persist() {
+    public void persist() {
         if (!isValid()) {
             return;
         }
@@ -251,7 +251,7 @@ public class MultiSelectionField<V> extends SelectionField<V, MultiSelectionFiel
      * Sets the field's current selection to its persistent selection, thus
      * resetting any changes made by the user.
      */
-    void reset() {
+    public void reset() {
         if (!hasChanged()) {
             return;
         }
@@ -262,7 +262,7 @@ public class MultiSelectionField<V> extends SelectionField<V, MultiSelectionFiel
     /**
      * {@inheritDoc}
      */
-    boolean validateRequired() {
+    protected boolean validateRequired() {
         return !isRequired() || (isRequired() && selection.size() > 0);
     }
 
@@ -273,7 +273,7 @@ public class MultiSelectionField<V> extends SelectionField<V, MultiSelectionFiel
      *
      * @return Returns whether the user selection is a valid value or not.
      */
-    boolean validate() {
+    public boolean validate() {
 
         // Check all validation rules and collect any error messages.
 

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/PasswordField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/PasswordField.java
@@ -44,7 +44,7 @@ public class PasswordField extends DataField<StringProperty, String, PasswordFie
      *              The property that is used to store the latest persisted
      *              value of the field.
      */
-    PasswordField(SimpleStringProperty valueProperty, SimpleStringProperty persistentValueProperty) {
+    protected PasswordField(SimpleStringProperty valueProperty, SimpleStringProperty persistentValueProperty) {
         super(valueProperty, persistentValueProperty);
 
         valueTransformer = String::valueOf;

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/Section.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/Section.java
@@ -43,17 +43,17 @@ public class Section extends Group {
      * This property is translatable if a {@link TranslationService} is set on
      * the containing form.
      */
-    private final StringProperty titleKey = new SimpleStringProperty("");
-    private final StringProperty title = new SimpleStringProperty("");
+    protected final StringProperty titleKey = new SimpleStringProperty("");
+    protected final StringProperty title = new SimpleStringProperty("");
 
     /**
      * A group can optionally be collapsed.
      */
-    private final BooleanProperty collapsed = new SimpleBooleanProperty(false);
+    protected final BooleanProperty collapsed = new SimpleBooleanProperty(false);
     /**
      * Section is collapsible by default
      */
-    private final BooleanProperty collapsible = new SimpleBooleanProperty(true);
+    protected final BooleanProperty collapsible = new SimpleBooleanProperty(true);
 
     /**
      * {@inheritDoc}
@@ -103,7 +103,7 @@ public class Section extends Group {
     /**
      * {@inheritDoc}
      */
-    void translate(TranslationService newValue) {
+    protected void translate(TranslationService newValue) {
         translationService = newValue;
 
         if (!isI18N()) {

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/SelectionField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/SelectionField.java
@@ -37,7 +37,7 @@ public abstract class SelectionField<V, F extends SelectionField<V, F>> extends 
     /**
      * Stores a typed list of available items on this field.
      */
-    final ListProperty<V> items;
+    protected final ListProperty<V> items;
 
     /**
      * Internal constructor for the {@code SelectionField} class. To create new
@@ -49,7 +49,7 @@ public abstract class SelectionField<V, F extends SelectionField<V, F>> extends 
      * @param items
      *              The list of available items on the field.
      */
-    SelectionField(ListProperty<V> items) {
+    protected SelectionField(ListProperty<V> items) {
         this.items = items;
     }
 
@@ -58,7 +58,7 @@ public abstract class SelectionField<V, F extends SelectionField<V, F>> extends 
      *
      * @return Returns whether the input matches the required condition.
      */
-    abstract boolean validateRequired();
+    protected abstract boolean validateRequired();
 
     /**
      * Validates a user input based on the field's selection and its validation
@@ -73,7 +73,7 @@ public abstract class SelectionField<V, F extends SelectionField<V, F>> extends 
      *
      * @return Returns whether the user selection is a valid value or not.
      */
-    boolean validate(List<String> errorMessages) {
+    protected boolean validate(List<String> errorMessages) {
         if (!validateRequired()) {
             if (isI18N() && requiredErrorKey.get() != null) {
                 this.errorMessageKeys.setAll(requiredErrorKey.get());

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/SingleSelectionField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/SingleSelectionField.java
@@ -46,14 +46,14 @@ public class SingleSelectionField<V> extends SelectionField<V, SingleSelectionFi
      * A {@code SingleSelectionField} can only ever have one item selected.
      * This item is stored in an {@code ObjectProperty}.
      */
-    private final ObjectProperty<V> persistentSelection = new SimpleObjectProperty<>();
-    private final ObjectProperty<V> selection = new SimpleObjectProperty<>();
+    protected final ObjectProperty<V> persistentSelection = new SimpleObjectProperty<>();
+    protected final ObjectProperty<V> selection = new SimpleObjectProperty<>();
 
     /**
      * Every field contains a list of validators. The validators are limited to
      * the ones that correspond to the field's type.
      */
-    private final List<Validator<V>> validators = new ArrayList<>();
+    protected final List<Validator<V>> validators = new ArrayList<>();
 
     /**
      * The constructor of {@code SingleSelectionField}.
@@ -63,7 +63,7 @@ public class SingleSelectionField<V> extends SelectionField<V, SingleSelectionFi
      * @param selection
      *              The index of the item that is to be selected.
      */
-    SingleSelectionField(ListProperty<V> items, int selection) {
+    protected SingleSelectionField(ListProperty<V> items, int selection) {
         super(items);
 
         // Sets the initial selection, based on an index. This also determines
@@ -236,7 +236,7 @@ public class SingleSelectionField<V> extends SelectionField<V, SingleSelectionFi
      * Stores the field's current value in its persistent value. This stores
      * the user's changes in the model.
      */
-    void persist() {
+    public void persist() {
         if (!isValid()) {
             return;
         }
@@ -248,7 +248,7 @@ public class SingleSelectionField<V> extends SelectionField<V, SingleSelectionFi
      * Sets the field's current value to its persistent value, thus resetting
      * any changes made by the user.
      */
-    void reset() {
+    public void reset() {
         if (!hasChanged()) {
             return;
         }
@@ -259,7 +259,7 @@ public class SingleSelectionField<V> extends SelectionField<V, SingleSelectionFi
     /**
      * {@inheritDoc}
      */
-    boolean validateRequired() {
+    protected boolean validateRequired() {
         return !isRequired() || (isRequired() && selection.get() != null);
     }
 
@@ -270,7 +270,7 @@ public class SingleSelectionField<V> extends SelectionField<V, SingleSelectionFi
      *
      * @return Returns whether the user selection is a valid value or not.
      */
-    boolean validate() {
+    public boolean validate() {
 
         // Check all validation rules and collect any error messages.
 

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/StringField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/StringField.java
@@ -35,7 +35,7 @@ import javafx.beans.property.StringProperty;
  */
 public class StringField extends DataField<StringProperty, String, StringField> {
 
-    private final BooleanProperty multiline = new SimpleBooleanProperty(false);
+    protected final BooleanProperty multiline = new SimpleBooleanProperty(false);
 
     /**
      * The constructor of {@code StringField}.
@@ -47,7 +47,7 @@ public class StringField extends DataField<StringProperty, String, StringField> 
      *              The property that is used to store the latest persisted
      *              value of the field.
      */
-    StringField(SimpleStringProperty valueProperty, SimpleStringProperty persistentValueProperty) {
+    protected StringField(SimpleStringProperty valueProperty, SimpleStringProperty persistentValueProperty) {
         super(valueProperty, persistentValueProperty);
 
         valueTransformer = String::valueOf;

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/validators/CustomValidator.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/validators/CustomValidator.java
@@ -34,7 +34,7 @@ public class CustomValidator<T> extends RootValidator<T> {
 
     private Predicate<T> callback;
 
-    CustomValidator(Predicate<T> callback, String errorMessage) {
+    protected CustomValidator(Predicate<T> callback, String errorMessage) {
         super(errorMessage);
         this.callback = callback;
     }

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/validators/RootValidator.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/validators/RootValidator.java
@@ -30,7 +30,7 @@ abstract class RootValidator<T> implements Validator<T> {
 
     private String errorMessage;
 
-    RootValidator(String errorMessage) {
+    protected RootValidator(String errorMessage) {
         this.errorMessage = errorMessage;
     }
 
@@ -42,7 +42,7 @@ abstract class RootValidator<T> implements Validator<T> {
      *
      * @return Returns a new ValidationResult containing result and message.
      */
-    ValidationResult createResult(boolean result) {
+    protected ValidationResult createResult(boolean result) {
         return new ValidationResult(result, errorMessage);
     }
 

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleBooleanControl.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleBooleanControl.java
@@ -40,9 +40,9 @@ public class SimpleBooleanControl extends SimpleControl<BooleanField> {
      * - checkBox is the editable checkbox to set user input.
      * - container holds the checkbox so that it can be styled properly.
      */
-    private Label fieldLabel;
-    private CheckBox checkBox;
-    private VBox container;
+    protected Label fieldLabel;
+    protected CheckBox checkBox;
+    protected VBox container;
 
     /**
      * {@inheritDoc}

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleCheckBoxControl.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleCheckBoxControl.java
@@ -43,9 +43,9 @@ public class SimpleCheckBoxControl<V> extends SimpleControl<MultiSelectionField<
      * - The checkboxes list contains all the checkboxes to display.
      * - The box is a VBox holding all box.
      */
-    private Label fieldLabel;
-    private final List<CheckBox> checkboxes = new ArrayList<>();
-    private VBox box;
+    protected Label fieldLabel;
+    protected final List<CheckBox> checkboxes = new ArrayList<>();
+    protected VBox box;
 
     /**
      * {@inheritDoc}
@@ -129,7 +129,7 @@ public class SimpleCheckBoxControl<V> extends SimpleControl<MultiSelectionField<
      * This method creates box and adds them to checkboxes and is
      * used when the itemsProperty on the field changes.
      */
-    private void createCheckboxes() {
+    protected void createCheckboxes() {
         box.getChildren().clear();
         checkboxes.clear();
 
@@ -148,7 +148,7 @@ public class SimpleCheckBoxControl<V> extends SimpleControl<MultiSelectionField<
     /**
      * Sets up bindings for all checkboxes.
      */
-    private void setupCheckboxBindings() {
+    protected void setupCheckboxBindings() {
         for (CheckBox checkbox : checkboxes) {
             checkbox.disableProperty().bind(field.editableProperty().not());
         }
@@ -157,7 +157,7 @@ public class SimpleCheckBoxControl<V> extends SimpleControl<MultiSelectionField<
     /**
      * Sets up event handlers for all checkboxes.
      */
-    private void setupCheckboxEventHandlers() {
+    protected void setupCheckboxEventHandlers() {
         for (int i = 0; i < checkboxes.size(); i++) {
             final int j = i;
 

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleComboBoxControl.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleComboBoxControl.java
@@ -43,10 +43,10 @@ public class SimpleComboBoxControl<V> extends SimpleControl<SingleSelectionField
      * - The readOnlyLabel is used to show the current selection in read only.
      * - The stack is a StackPane to hold the field and read only label.
      */
-    private Label fieldLabel;
-    private ComboBox<V> comboBox;
-    private Label readOnlyLabel;
-    private StackPane stack;
+    protected Label fieldLabel;
+    protected ComboBox<V> comboBox;
+    protected Label readOnlyLabel;
+    protected StackPane stack;
 
     /**
      * {@inheritDoc}

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleControl.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleControl.java
@@ -48,7 +48,7 @@ public abstract class SimpleControl<F extends Field> extends GridPane implements
     /**
      * Tooltip to hold the error message.
      */
-    Tooltip tooltip;
+    protected Tooltip tooltip;
 
     /**
      * Pseudo classes for state changes.

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleListViewControl.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleListViewControl.java
@@ -40,13 +40,13 @@ public class SimpleListViewControl<V> extends SimpleControl<MultiSelectionField<
      *   the field.
      * - The listView is the container that displays list values.
      */
-    private Label fieldLabel;
-    private ListView<String> listView = new ListView<>();
+    protected Label fieldLabel;
+    protected ListView<String> listView = new ListView<>();
 
     /**
      * The flag used for setting the selection properly.
      */
-    private boolean preventUpdate;
+    protected boolean preventUpdate;
 
     /**
      * {@inheritDoc}

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleNumberControl.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleNumberControl.java
@@ -40,7 +40,7 @@ public abstract class SimpleNumberControl<F extends DataField, D extends Number>
      * the {@code readOnlyLabel} over the {@code editableSpinner} on the change
      * of the {@code visibleProperty}.
      */
-    private StackPane stack;
+    protected StackPane stack;
 
     /**
      * - The fieldLabel is the container that displays the label property of
@@ -48,9 +48,9 @@ public abstract class SimpleNumberControl<F extends DataField, D extends Number>
      * - The editableSpinner is a Spinner for setting numerical values.
      * - The readOnlyLabel is the label to put over editableSpinner.
      */
-    private Label fieldLabel;
+    protected Label fieldLabel;
     protected Spinner<D> editableSpinner;
-    private Label readOnlyLabel;
+    protected Label readOnlyLabel;
 
     /**
      * {@inheritDoc}

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimplePasswordControl.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimplePasswordControl.java
@@ -42,7 +42,7 @@ public class SimplePasswordControl extends SimpleControl<PasswordField> {
      * the readOnlyLabel over the editableField on the change of the
      * visibleProperty.
      */
-    private StackPane stack;
+    protected StackPane stack;
 
     /**
      * - The fieldLabel is the container that displays the label property of
@@ -50,14 +50,14 @@ public class SimplePasswordControl extends SimpleControl<PasswordField> {
      * - The editableField allows users to modify the field's value.
      * - The readOnlyLabel displays the field's value if it is not editable.
      */
-    private javafx.scene.control.PasswordField editableField;
-    private Label readOnlyLabel;
-    private Label fieldLabel;
+    protected javafx.scene.control.PasswordField editableField;
+    protected Label readOnlyLabel;
+    protected Label fieldLabel;
 
     /*
      * Translates characters found in user input into '*'
      */
-    private StringBinding obfuscatedUserInputBinding;
+    protected StringBinding obfuscatedUserInputBinding;
 
     /**
      * {@inheritDoc}
@@ -134,7 +134,7 @@ public class SimplePasswordControl extends SimpleControl<PasswordField> {
         editableField.focusedProperty().addListener((observable, oldValue, newValue) -> toggleTooltip(editableField));
     }
 
-    private String obfuscate(String input) {
+    protected String obfuscate(String input) {
         if (input == null) { return ""; }
         int length = input.length();
         StringBuilder b = new StringBuilder();

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleRadioButtonControl.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleRadioButtonControl.java
@@ -45,10 +45,10 @@ public class SimpleRadioButtonControl<V> extends SimpleControl<SingleSelectionFi
      * - The toggleGroup defines the group for the radio buttons.
      * - The box is a VBox holding all radio buttons.
      */
-    private Label fieldLabel;
-    private final List<RadioButton> radioButtons = new ArrayList<>();
-    private ToggleGroup toggleGroup;
-    private VBox box;
+    protected Label fieldLabel;
+    protected final List<RadioButton> radioButtons = new ArrayList<>();
+    protected ToggleGroup toggleGroup;
+    protected VBox box;
 
     /**
      * {@inheritDoc}
@@ -131,7 +131,7 @@ public class SimpleRadioButtonControl<V> extends SimpleControl<SingleSelectionFi
      * This method creates radio buttons and adds them to radioButtons
      * and is used when the itemsProperty on the field changes.
      */
-    private void createRadioButtons() {
+    protected void createRadioButtons() {
         box.getChildren().clear();
         radioButtons.clear();
 
@@ -154,7 +154,7 @@ public class SimpleRadioButtonControl<V> extends SimpleControl<SingleSelectionFi
     /**
      * Sets up bindings for all radio buttons.
      */
-    private void setupRadioButtonBindings() {
+    protected void setupRadioButtonBindings() {
         for (RadioButton radio : radioButtons) {
             radio.disableProperty().bind(field.editableProperty().not());
         }
@@ -163,7 +163,7 @@ public class SimpleRadioButtonControl<V> extends SimpleControl<SingleSelectionFi
     /**
      * Sets up bindings for all radio buttons.
      */
-    private void setupRadioButtonEventHandlers() {
+    protected void setupRadioButtonEventHandlers() {
         for (int i = 0; i < radioButtons.size(); i++) {
             final int j = i;
             radioButtons.get(j).setOnAction(event -> field.select(j));

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleTextControl.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleTextControl.java
@@ -42,7 +42,7 @@ public class SimpleTextControl extends SimpleControl<StringField> {
      * the readOnlyLabel over the editableField on the change of the
      * visibleProperty.
      */
-    private StackPane stack;
+    protected StackPane stack;
 
     /**
      * - The fieldLabel is the container that displays the label property of
@@ -50,10 +50,10 @@ public class SimpleTextControl extends SimpleControl<StringField> {
      * - The editableField allows users to modify the field's value.
      * - The readOnlyLabel displays the field's value if it is not editable.
      */
-    private TextField editableField;
-    private TextArea editableArea;
-    private Label readOnlyLabel;
-    private Label fieldLabel;
+    protected TextField editableField;
+    protected TextArea editableArea;
+    protected Label readOnlyLabel;
+    protected Label fieldLabel;
 
     /**
      * {@inheritDoc}

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/view/renderer/FormRenderer.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/view/renderer/FormRenderer.java
@@ -38,8 +38,8 @@ import java.util.stream.Collectors;
  */
 public class FormRenderer extends VBox implements ViewMixin {
 
-    private Form form;
-    private List<GroupRendererBase> sections = new ArrayList<>();
+    protected Form form;
+    protected List<GroupRendererBase> sections = new ArrayList<>();
 
     /**
      * This is the constructor to pass over data.

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/view/renderer/GroupRenderer.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/view/renderer/GroupRenderer.java
@@ -37,7 +37,7 @@ public class GroupRenderer extends GroupRendererBase {
      * @param group
      *              The section which gets rendered.
      */
-    GroupRenderer(Group group) {
+    protected GroupRenderer(Group group) {
         this.element = group;
         init();
     }

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/view/renderer/SectionRenderer.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/view/renderer/SectionRenderer.java
@@ -39,7 +39,7 @@ public class SectionRenderer extends GroupRendererBase<Section> {
      * @param section
      *              The section which gets rendered.
      */
-    SectionRenderer(Section section) {
+    protected SectionRenderer(Section section) {
         this.element = section;
         init();
     }


### PR DESCRIPTION
Fix for #27.

- Migrated all private state to protected for `Field`, `SimpleControl` and their subclasses.
- Package private state was migrated to protected.
- Package private constructors were migrated to protected.
- There were a handful of package private methods (`persist`, `reset`, `validate`) that were migrated to public as some of the subclasses had overridden the methods with public modifier.

These changes will enable consumers to create custom `Field` and `SimpleControl` subclasses without having to place their classes in the same package as the original FormsFX classes (a big no-no in modular codebases as split-package definition is prohibited!).

In my experience implementing a library with package private in mind makes it quite hard for consumers to fill in gaps with custom implementations, it would be better to keep our options open (`protected`)  but not wildly open (`public`). Of course the usage of package private is a matter of taste and particular design goals that may not (or appear not to) be explicit.