### PR TITLE
Enable additional content inside Form/Section/Group

### DIFF
--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/DataField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/DataField.java
@@ -43,7 +43,7 @@ import java.util.stream.Collectors;
  * @author Sacha Schmid
  * @author Rinesch Murugathas
  */
-public class DataField<P extends Property, V, F extends Field> extends Field<F> {
+public class DataField<P extends Property, V, F extends Field<F>> extends Field<F> {
 
     /**
      * Every field tracks its value in multiple ways.
@@ -89,7 +89,7 @@ public class DataField<P extends Property, V, F extends Field> extends Field<F> 
 
     /**
      * Internal constructor for the {@code DataField} class. To create new
-     * fields, see the static factory methods in {@code Field}.
+     * elements, see the static factory methods in {@code Field}.
      *
      * @see Field::ofStringType
      * @see Field::ofIntegerType
@@ -114,7 +114,7 @@ public class DataField<P extends Property, V, F extends Field> extends Field<F> 
 
         changed.bind(Bindings.createBooleanBinding(() -> !String.valueOf(persistentValue.getValue()).equals(userInput.getValue()), userInput, persistentValue));
 
-        // Whenever one of the translatable fields' keys change, update the
+        // Whenever one of the translatable elements' keys change, update the
         // displayed value based on the new translation.
 
         formatErrorKey.addListener((observable, oldValue, newValue) -> formatError.setValue(translationService.translate(newValue)));
@@ -256,7 +256,7 @@ public class DataField<P extends Property, V, F extends Field> extends Field<F> 
      * Stores the field's current value in its persistent value. This stores
      * the user's changes in the model.
      */
-    void persist() {
+    public void persist() {
         if (!isValid()) {
             return;
         }
@@ -268,7 +268,7 @@ public class DataField<P extends Property, V, F extends Field> extends Field<F> 
      * Sets the field's current value to its persistent value, thus resetting
      * any changes made by the user.
      */
-    void reset() {
+    public void reset() {
         if (!hasChanged()) {
             return;
         }

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/Element.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/Element.java
@@ -1,0 +1,121 @@
+package com.dlsc.formsfx.model.structure;
+
+/*-
+ * ========================LICENSE_START=================================
+ * FormsFX
+ * %%
+ * Copyright (C) 2017 - 2018 DLSC Software & Consulting
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import com.dlsc.formsfx.view.util.ColSpan;
+import javafx.beans.property.IntegerProperty;
+import javafx.beans.property.ListProperty;
+import javafx.beans.property.SimpleIntegerProperty;
+import javafx.beans.property.SimpleListProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+
+import java.util.UUID;
+
+/**
+ * @author Andres Almiray
+ */
+public abstract class Element<E extends Element<E>> {
+    /**
+     * Fields can be styled using CSS through ID or class hooks.
+     */
+    protected final StringProperty id = new SimpleStringProperty(UUID.randomUUID().toString());
+    protected final ListProperty<String> styleClass = new SimpleListProperty<>(FXCollections.observableArrayList());
+    protected final IntegerProperty span = new SimpleIntegerProperty(12);
+
+    /**
+     * Sets the id property of the current field.
+     *
+     * @param newValue
+     *              The new value for the id property.
+     *
+     * @return Returns the current field to allow for chaining.
+     */
+    public E id(String newValue) {
+        id.set(newValue);
+        return (E) this;
+    }
+
+    /**
+     * Sets the style classes for the current field.
+     *
+     * @param newValue
+     *              The new style classes.
+     *
+     * @return Returns the current field to allow for chaining.
+     */
+    public E styleClass(String... newValue) {
+        styleClass.setAll(newValue);
+        return (E) this;
+    }
+
+    /**
+     * Sets the amount of columns the field takes up inside the section grid.
+     *
+     * @param newValue
+     *              The new number of columns.
+     *
+     * @return Returns the current field to allow for chaining.
+     */
+    public E span(int newValue) {
+        span.setValue(newValue);
+        return (E) this;
+    }
+
+    /**
+     * Sets the amount of columns the field takes up inside the section grid.
+     *
+     * @param newValue
+     *              The new span fraction.
+     *
+     * @return Returns the current field to allow for chaining.
+     */
+    public E span(ColSpan newValue) {
+        span.setValue(newValue.valueOf());
+        return (E) this;
+    }
+
+    public int getSpan() {
+        return span.get();
+    }
+
+    public IntegerProperty spanProperty() {
+        return span;
+    }
+
+    public String getID() {
+        return id.get();
+    }
+
+    public StringProperty idProperty() {
+        return id;
+    }
+
+    public ObservableList<String> getStyleClass() {
+        return styleClass.get();
+    }
+
+    public ListProperty<String> styleClassProperty() {
+        return styleClass;
+    }
+}

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/Field.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/Field.java
@@ -23,7 +23,6 @@ package com.dlsc.formsfx.model.structure;
 import com.dlsc.formsfx.model.util.BindingMode;
 import com.dlsc.formsfx.model.util.TranslationService;
 import com.dlsc.formsfx.view.controls.SimpleControl;
-import com.dlsc.formsfx.view.util.ColSpan;
 import javafx.beans.InvalidationListener;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.DoubleProperty;
@@ -37,11 +36,9 @@ import javafx.beans.property.SimpleListProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.collections.FXCollections;
-import javafx.collections.ObservableList;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 /**
@@ -55,7 +52,7 @@ import java.util.stream.Collectors;
  * @author Sacha Schmid
  * @author Rinesch Murugathas
  */
-public abstract class Field<F extends Field> {
+public abstract class Field<F extends Field<F>> extends Element<F> implements FormElement {
 
     /**
      * The label acts as a description for the field. It is always visible to
@@ -104,13 +101,6 @@ public abstract class Field<F extends Field> {
     final BooleanProperty changed = new SimpleBooleanProperty(false);
 
     /**
-     * Fields can be styled using CSS through ID or class hooks.
-     */
-    private final StringProperty id = new SimpleStringProperty(UUID.randomUUID().toString());
-    private final ListProperty<String> styleClass = new SimpleListProperty<>(FXCollections.observableArrayList());
-    private final IntegerProperty span = new SimpleIntegerProperty(12);
-
-    /**
      * The results of the field's validation is stored in this property. After
      * every validation, the results are updated and reflected in this property.
      *
@@ -139,7 +129,7 @@ public abstract class Field<F extends Field> {
     };
 
     /**
-     * Internal constructor for the {@code Field} class. To create new fields,
+     * Internal constructor for the {@code Field} class. To create new elements,
      * see the static factory methods in this class.
      *
      * @see Field::ofStringType
@@ -151,7 +141,7 @@ public abstract class Field<F extends Field> {
      */
     Field() {
 
-        // Whenever one of the translatable fields' keys change, update the
+        // Whenever one of the translatable elements' keys change, update the
         // displayed value based on the new translation.
 
         labelKey.addListener((observable, oldValue, newValue) -> label.setValue(translationService.translate(newValue)));
@@ -331,7 +321,7 @@ public abstract class Field<F extends Field> {
      *
      * @return Returns a new {@link MultiSelectionField}.
      */
-    public static <T> MultiSelectionField ofMultiSelectionType(ListProperty<T> itemsBinding, ListProperty<T> selectionBinding) {
+    public static <T> MultiSelectionField<T> ofMultiSelectionType(ListProperty<T> itemsBinding, ListProperty<T> selectionBinding) {
         return new MultiSelectionField<>(new SimpleListProperty<>(itemsBinding.getValue()), new ArrayList<>(selectionBinding.getValue().stream().map(t -> itemsBinding.getValue().indexOf(t)).collect(Collectors.toList()))).bind(itemsBinding, selectionBinding);
     }
 
@@ -494,32 +484,6 @@ public abstract class Field<F extends Field> {
     }
 
     /**
-     * Sets the id property of the current field.
-     *
-     * @param newValue
-     *              The new value for the id property.
-     *
-     * @return Returns the current field to allow for chaining.
-     */
-    public F id(String newValue) {
-        id.set(newValue);
-        return (F) this;
-    }
-
-    /**
-     * Sets the style classes for the current field.
-     *
-     * @param newValue
-     *              The new style classes.
-     *
-     * @return Returns the current field to allow for chaining.
-     */
-    public F styleClass(String... newValue) {
-        styleClass.setAll(newValue);
-        return (F) this;
-    }
-
-    /**
      * Sets the control that renders this field.
      *
      * @param newValue
@@ -533,32 +497,6 @@ public abstract class Field<F extends Field> {
     }
 
     /**
-     * Sets the amount of columns the field takes up inside the section grid.
-     *
-     * @param newValue
-     *              The new number of columns.
-     *
-     * @return Returns the current field to allow for chaining.
-     */
-    public F span(int newValue) {
-        span.setValue(newValue);
-        return (F) this;
-    }
-
-    /**
-     * Sets the amount of columns the field takes up inside the section grid.
-     *
-     * @param newValue
-     *              The new span fraction.
-     *
-     * @return Returns the current field to allow for chaining.
-     */
-    public F span(ColSpan newValue) {
-        span.setValue(newValue.valueOf());
-        return (F) this;
-    }
-
-    /**
      * Activates or deactivates the {@code bindingModeListener} based on the
      * given {@code BindingMode}.
      *
@@ -567,9 +505,9 @@ public abstract class Field<F extends Field> {
      */
     abstract void setBindingMode(BindingMode newValue);
 
-    abstract void persist();
+    // abstract void persist();
 
-    abstract void reset();
+    // abstract void reset();
 
     /**
      * This internal method is called by the containing section when a new
@@ -685,30 +623,6 @@ public abstract class Field<F extends Field> {
 
     public boolean isI18N() {
         return translationService != null;
-    }
-
-    public int getSpan() {
-        return span.get();
-    }
-
-    public IntegerProperty spanProperty() {
-        return span;
-    }
-
-    public String getID() {
-        return id.get();
-    }
-
-    public StringProperty idProperty() {
-        return id;
-    }
-
-    public ObservableList<String> getStyleClass() {
-        return styleClass.get();
-    }
-
-    public ListProperty<String> styleClassProperty() {
-        return styleClass;
     }
 
     public SimpleControl<F> getRenderer() {

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/Form.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/Form.java
@@ -35,7 +35,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /**
- * A form is the containing unit for sections and fields and is used to bring
+ * A form is the containing unit for sections and elements and is used to bring
  * structure to form data. It also acts as a proxy to some properties of the
  * contained data, such as validity or changes.
  *
@@ -201,7 +201,7 @@ public class Form {
     }
 
     /**
-     * Persists the values for all fields contained in this form's groups.
+     * Persists the values for all elements contained in this form's groups.
      *
      * @see Field::reset
      */
@@ -214,7 +214,7 @@ public class Form {
     }
 
     /**
-     * Resets the values for all fields contained in this form's groups.
+     * Resets the values for all elements contained in this form's groups.
      *
      * @see Field::reset
      */
@@ -256,11 +256,20 @@ public class Form {
         return groups;
     }
 
-    public List<Field> getFields() {
+    public List<Element> getElements() {
         return groups.stream()
-                .map(Group::getFields)
+                .map(Group::getElements)
                 .flatMap(List::stream)
                 .collect(Collectors.toList());
+    }
+
+    public List<Field> getFields() {
+        return groups.stream()
+            .map(Group::getElements)
+            .flatMap(List::stream)
+            .filter(e -> e instanceof Field)
+            .map(e -> (Field) e)
+            .collect(Collectors.toList());
     }
 
     public boolean hasChanged() {

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/FormElement.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/FormElement.java
@@ -1,0 +1,30 @@
+package com.dlsc.formsfx.model.structure;
+
+/*-
+ * ========================LICENSE_START=================================
+ * FormsFX
+ * %%
+ * Copyright (C) 2017 - 2018 DLSC Software & Consulting
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+/**
+ * @author Andres Almiray
+ */
+public interface FormElement {
+    void persist();
+
+    void reset();
+}

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/Group.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/Group.java
@@ -31,7 +31,7 @@ import java.util.List;
 
 /**
  * A group is the intermediate unit in a form. It is used to group form
- * fields to a larger unit. It also acts as a proxy to some properties of
+ * elements to a larger unit. It also acts as a proxy to some properties of
  * the contained data, such as validity or changes.
  *
  * @author Sacha Schmid
@@ -39,10 +39,10 @@ import java.util.List;
  */
 public class Group {
 
-    protected final List<Field> fields = new ArrayList<>();
+    protected final List<Element> elements = new ArrayList<>();
 
     /**
-     * The group acts as a proxy for its contained fields' {@code changed}
+     * The group acts as a proxy for its contained elements' {@code changed}
      * and {@code valid} properties.
      */
     private final BooleanProperty valid = new SimpleBooleanProperty(true);
@@ -60,43 +60,49 @@ public class Group {
      *
      * @see Group::of
      *
-     * @param fields
-     *              A varargs list of fields that are contained in this
+     * @param elements
+     *              A varargs list of elements that are contained in this
      *              group.
      */
-    protected Group(Field... fields) {
-        Collections.addAll(this.fields, fields);
+    protected Group(Element... elements) {
+        Collections.addAll(this.elements, elements);
 
-        // If any of the fields are marked as changed, the group is updated
+        // If any of the elements are marked as changed, the group is updated
         // accordingly.
 
-        this.fields.forEach(f -> f.changedProperty().addListener((observable, oldValue, newValue) -> setChangedProperty()));
+        this.elements.stream()
+            .filter(e -> e instanceof Field)
+            .map(e -> (Field) e)
+            .forEach(f -> f.changedProperty().addListener((observable, oldValue, newValue) -> setChangedProperty()));
 
-        // If any of the fields are marked as invalid, the group is updated
+        // If any of the elements are marked as invalid, the group is updated
         // accordingly.
 
-        this.fields.forEach(f -> f.validProperty().addListener((observable, oldValue, newValue) -> setValidProperty()));
+        this.elements.stream()
+            .filter(e -> e instanceof Field)
+            .map(e -> (Field) e)
+            .forEach(f -> f.validProperty().addListener((observable, oldValue, newValue) -> setValidProperty()));
 
         setValidProperty();
         setChangedProperty();
     }
 
     /**
-     * Creates a new group containing the given fields.
+     * Creates a new group containing the given elements.
      *
-     * @param fields
-     *              The fields to be included in the group.
+     * @param elements
+     *              The elements to be included in the group.
      *
      * @return Returns a new {@code Group}.
      */
-    public static Group of(Field... fields) {
-        return new Group(fields);
+    public static Group of(Element... elements) {
+        return new Group(elements);
     }
 
     /**
      * This internal method is called by the containing form when a new
      * translation has been added to the form. Also applies the translation
-     * to all contained fields.
+     * to all contained elements.
      *
      * @see Field::translate
      *
@@ -110,11 +116,14 @@ public class Group {
             return;
         }
 
-        fields.forEach(f -> f.translate(translationService));
+        elements.stream()
+            .filter(e -> e instanceof Field)
+            .map(e -> (Field) e)
+            .forEach(f -> f.translate(translationService));
     }
 
     /**
-     * Persists the values for all contained fields.
+     * Persists the values for all contained elements.
      * @see Field::persist
      */
     void persist() {
@@ -122,11 +131,14 @@ public class Group {
             return;
         }
 
-        fields.forEach(Field::persist);
+        elements.stream()
+            .filter(e -> e instanceof FormElement)
+            .map(e -> (FormElement) e)
+            .forEach(FormElement::persist);
     }
 
     /**
-     * Resets the values for all contained fields.
+     * Resets the values for all contained elements.
      * @see Field::reset
      */
     void reset() {
@@ -134,27 +146,36 @@ public class Group {
             return;
         }
 
-        fields.forEach(Field::reset);
+        elements.stream()
+            .filter(e -> e instanceof FormElement)
+            .map(e -> (FormElement) e)
+            .forEach(FormElement::reset);
     }
 
     /**
      * Sets this group's {@code changed} property based on its contained
-     * fields' changed properties.
+     * elements' changed properties.
      */
     private void setChangedProperty() {
-        changed.setValue(fields.stream().anyMatch(Field::hasChanged));
+        changed.setValue(elements.stream()
+            .filter(e -> e instanceof Field)
+            .map(e -> (Field) e)
+            .anyMatch(Field::hasChanged));
     }
 
     /**
-     * Sets this group's {@code valid} property based on its contained fields'
+     * Sets this group's {@code valid} property based on its contained elements'
      * changed properties.
      */
     private void setValidProperty() {
-        valid.setValue(fields.stream().allMatch(Field::isValid));
+        valid.setValue(elements.stream()
+            .filter(e -> e instanceof Field)
+            .map(e -> (Field) e)
+            .allMatch(Field::isValid));
     }
 
-    public List<Field> getFields() {
-        return fields;
+    public List<Element> getElements() {
+        return elements;
     }
 
     public boolean hasChanged() {

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/MultiSelectionField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/MultiSelectionField.java
@@ -188,7 +188,7 @@ public class MultiSelectionField<V> extends SelectionField<V, MultiSelectionFiel
 
     /**
      * Binds the given items and selection property with the corresponding
-     * fields.
+     * elements.
      *
      * @param itemsBinding
      *          The items property to be bound with.
@@ -207,7 +207,7 @@ public class MultiSelectionField<V> extends SelectionField<V, MultiSelectionFiel
 
     /**
      * Unbinds the given items and selection property with the corresponding
-     * fields.
+     * elements.
      *
      * @param itemsBinding
      *          The items property to be unbound with.
@@ -239,7 +239,7 @@ public class MultiSelectionField<V> extends SelectionField<V, MultiSelectionFiel
      * Stores the field's current selection in its persistent selection. This
      * stores the user's changes in the model.
      */
-    void persist() {
+    public void persist() {
         if (!isValid()) {
             return;
         }
@@ -251,7 +251,7 @@ public class MultiSelectionField<V> extends SelectionField<V, MultiSelectionFiel
      * Sets the field's current selection to its persistent selection, thus
      * resetting any changes made by the user.
      */
-    void reset() {
+    public void reset() {
         if (!hasChanged()) {
             return;
         }

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/NodeElement.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/NodeElement.java
@@ -1,0 +1,45 @@
+package com.dlsc.formsfx.model.structure;
+
+/*-
+ * ========================LICENSE_START=================================
+ * FormsFX
+ * %%
+ * Copyright (C) 2017 - 2018 DLSC Software & Consulting
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import javafx.scene.Node;
+
+/**
+ * @author Andres Almiray
+ */
+public class NodeElement<N extends Node> extends Element {
+    protected N node;
+
+    public static <T extends Node> NodeElement<T> of(T node) {
+        return new NodeElement(node);
+    }
+
+    protected NodeElement(N node) {
+        if (node == null) {
+            throw new NullPointerException("Node argument must not be null");
+        }
+        this.node = node;
+    }
+
+    public N getNode() {
+        return node;
+    }
+}

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/Section.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/Section.java
@@ -29,7 +29,7 @@ import javafx.beans.property.StringProperty;
 /**
  * A section is a kind of group with more options. It can have a title and can
  * be collapsed by the user. Sections represent a more semantically heavy
- * grouping of fields, compared to groups.
+ * grouping of elements, compared to groups.
  *
  * @author Sacha Schmid
  * @author Rinesch Murugathas
@@ -38,7 +38,7 @@ public class Section extends Group {
 
     /**
      * The title acts as a description for the group. It is always visible to
-     * the user and tells them how the contained fields are grouped.
+     * the user and tells them how the contained elements are grouped.
      *
      * This property is translatable if a {@link TranslationService} is set on
      * the containing form.
@@ -58,8 +58,8 @@ public class Section extends Group {
     /**
      * {@inheritDoc}
      */
-    private Section(Field... fields) {
-        super(fields);
+    private Section(Element... elements) {
+        super(elements);
 
         // Whenever the title's key changes, update the displayed value based
         // on the new translation.
@@ -68,15 +68,15 @@ public class Section extends Group {
     }
 
     /**
-     * Creates a new section containing the given fields.
+     * Creates a new section containing the given elements.
      *
-     * @param fields
-     *              The fields to be included in the section.
+     * @param elements
+     *              The elements to be included in the section.
      *
      * @return Returns a new {@code Section}.
      */
-    public static Section of(Field... fields) {
-        return new Section(fields);
+    public static Section of(Element... elements) {
+        return new Section(elements);
     }
 
     /**
@@ -116,7 +116,10 @@ public class Section extends Group {
             title.setValue(translationService.translate(titleKey.get()));
         }
 
-        fields.forEach(f -> f.translate(translationService));
+        elements.stream()
+            .filter(e -> e instanceof Field)
+            .map(e -> (Field) e)
+            .forEach(f -> f.translate(translationService));
     }
 
     /**

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/SelectionField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/SelectionField.java
@@ -41,7 +41,7 @@ public abstract class SelectionField<V, F extends SelectionField<V, F>> extends 
 
     /**
      * Internal constructor for the {@code SelectionField} class. To create new
-     * fields, see the static factory methods in {@code Field}.
+     * elements, see the static factory methods in {@code Field}.
      *
      * @see Field::ofMultiSelectionType
      * @see Field::ofSingleSelectionType

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/SingleSelectionField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/SingleSelectionField.java
@@ -185,7 +185,7 @@ public class SingleSelectionField<V> extends SelectionField<V, SingleSelectionFi
 
     /**
      * Binds the given items and selection property with the corresponding
-     * fields.
+     * elements.
      *
      * @param itemsBinding
      *          The items property to be bound with.
@@ -204,7 +204,7 @@ public class SingleSelectionField<V> extends SelectionField<V, SingleSelectionFi
 
     /**
      * Unbinds the given items and selection property with the corresponding
-     * fields.
+     * elements.
      *
      * @param itemsBinding
      *          The items property to be unbound with.
@@ -236,7 +236,7 @@ public class SingleSelectionField<V> extends SelectionField<V, SingleSelectionFi
      * Stores the field's current value in its persistent value. This stores
      * the user's changes in the model.
      */
-    void persist() {
+    public void persist() {
         if (!isValid()) {
             return;
         }
@@ -248,7 +248,7 @@ public class SingleSelectionField<V> extends SelectionField<V, SingleSelectionFi
      * Sets the field's current value to its persistent value, thus resetting
      * any changes made by the user.
      */
-    void reset() {
+    public void reset() {
         if (!hasChanged()) {
             return;
         }

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleNumberControl.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleNumberControl.java
@@ -28,7 +28,7 @@ import javafx.scene.layout.StackPane;
 
 /**
  * This class provides the base implementation for a simple control to edit
- * numerical fields.
+ * numerical elements.
  *
  * @author Rinesch Murugathas
  * @author Sacha Schmid

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/view/renderer/GroupRendererBase.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/view/renderer/GroupRendererBase.java
@@ -20,8 +20,10 @@ package com.dlsc.formsfx.view.renderer;
  * =========================LICENSE_END==================================
  */
 
+import com.dlsc.formsfx.model.structure.Element;
 import com.dlsc.formsfx.model.structure.Field;
 import com.dlsc.formsfx.model.structure.Group;
+import com.dlsc.formsfx.model.structure.NodeElement;
 import com.dlsc.formsfx.view.controls.SimpleControl;
 import com.dlsc.formsfx.view.util.ViewMixin;
 import javafx.geometry.Insets;
@@ -78,18 +80,23 @@ public abstract class GroupRendererBase<V extends Group> extends StackPane imple
         // Add the controls in the GridPane in a 12-column layout. If a control
         // takes up too much horizontal space, wrap it to the next row.
 
-        for (Field f : element.getFields()) {
-            int span = f.getSpan();
+        for (Element e : element.getElements()) {
+            int span = e.getSpan();
 
             if (currentColumnCount + span > COLUMN_COUNT) {
                 currentRow += 1;
                 currentColumnCount = 0;
             }
 
-            SimpleControl c = f.getRenderer();
-            c.setField(f);
+            if (e instanceof Field) {
+                Field f = (Field) e;
+                SimpleControl c = f.getRenderer();
+                c.setField(f);
 
-            grid.add(c, currentColumnCount, currentRow, span, 1);
+                grid.add(c, currentColumnCount, currentRow, span, 1);
+            } else if (e instanceof NodeElement){
+                grid.add(((NodeElement)e).getNode(), currentColumnCount, currentRow, span, 1);
+            }
 
             currentColumnCount += span;
         }

--- a/formsfx-core/src/test/java/com/dlsc/formsfx/model/structure/FormTest.java
+++ b/formsfx-core/src/test/java/com/dlsc/formsfx/model/structure/FormTest.java
@@ -64,7 +64,7 @@ public class FormTest {
                 )
         );
 
-        Assert.assertEquals(6, f.getFields().size());
+        Assert.assertEquals(6, f.getElements().size());
         Assert.assertEquals(4, f.getGroups().size());
     }
 


### PR DESCRIPTION
Fix for #23 

**WORK IN PROGRESS!!**

This PR adds a new base type `Element` that can identify regular `Field`s and plain content (`Node`).
Instances of `NodeElement` can be used to attach arbitrary content to a `Group` within the boundaries of its grid, as shown by the following screenshot

<img width="1235" alt="formsfx-additional-content" src="https://user-images.githubusercontent.com/13969/42535919-1318b77c-8491-11e8-8d9a-f9d1eddec3d4.png">

The code added to the end of the `Section` definition is

    NodeElement.of(new javafx.scene.control.Label("Somebody setup us the bomb"))
                                   .span(ColSpan.HALF),
    NodeElement.of(new javafx.scene.control.Label("All your forms are belong to us. What you say? Move every zig. For great justice!"))

I'm not particularly fond on the current implementation of `GroupRendererBase` to identify how a particular element should be rendered, as it can only identify `Field` and `NodeElement`.

Feedback welcome.