### PR TITLE
Create renderers lazily

### DIFF
--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/BooleanField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/BooleanField.java
@@ -53,7 +53,7 @@ public class BooleanField extends DataField<BooleanProperty, Boolean, BooleanFie
                 return Boolean.parseBoolean(string);
             }
         };
-        renderer = () -> new SimpleBooleanControl();
+        rendererSupplier = () -> new SimpleBooleanControl();
 
         userInput.set(stringConverter.toString(value.getValue()));
     }

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/BooleanField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/BooleanField.java
@@ -53,7 +53,7 @@ public class BooleanField extends DataField<BooleanProperty, Boolean, BooleanFie
                 return Boolean.parseBoolean(string);
             }
         };
-        renderer = new SimpleBooleanControl();
+        renderer = () -> new SimpleBooleanControl();
 
         userInput.set(stringConverter.toString(value.getValue()));
     }

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/DateField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/DateField.java
@@ -54,7 +54,7 @@ public class DateField extends DataField<ObjectProperty<LocalDate>, LocalDate, D
 
         Chronology chronology = Chronology.ofLocale(Locale.getDefault(Locale.Category.FORMAT));
         stringConverter = new LocalDateStringConverter(FormatStyle.SHORT, null, chronology);
-        renderer = new SimpleDateControl();
+        renderer = () -> new SimpleDateControl();
         userInput.setValue(null);
         userInput.setValue(stringConverter.toString((LocalDate) persistentValue.getValue()));
     }

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/DateField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/DateField.java
@@ -54,7 +54,7 @@ public class DateField extends DataField<ObjectProperty<LocalDate>, LocalDate, D
 
         Chronology chronology = Chronology.ofLocale(Locale.getDefault(Locale.Category.FORMAT));
         stringConverter = new LocalDateStringConverter(FormatStyle.SHORT, null, chronology);
-        renderer = () -> new SimpleDateControl();
+        rendererSupplier = () -> new SimpleDateControl();
         userInput.setValue(null);
         userInput.setValue(stringConverter.toString((LocalDate) persistentValue.getValue()));
     }

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/DoubleField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/DoubleField.java
@@ -52,7 +52,7 @@ public class DoubleField extends DataField<DoubleProperty, Double, DoubleField> 
                 return Double.parseDouble(string);
             }
         };
-        renderer = () -> new SimpleDoubleControl();
+        rendererSupplier = () -> new SimpleDoubleControl();
 
         userInput.set(stringConverter.toString(value.getValue()));
     }

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/DoubleField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/DoubleField.java
@@ -52,7 +52,7 @@ public class DoubleField extends DataField<DoubleProperty, Double, DoubleField> 
                 return Double.parseDouble(string);
             }
         };
-        renderer = new SimpleDoubleControl();
+        renderer = () -> new SimpleDoubleControl();
 
         userInput.set(stringConverter.toString(value.getValue()));
     }

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/Field.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/Field.java
@@ -145,7 +145,8 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
      */
     protected TranslationService translationService;
 
-    protected Supplier<SimpleControl<F>> renderer;
+    protected SimpleControl<F> renderer;
+    protected Supplier<SimpleControl<F>> rendererSupplier;
 
     protected final Map<EventType<FieldEvent>,List<EventHandler<? super FieldEvent>>> eventHandlers = new ConcurrentHashMap<>();
 
@@ -629,8 +630,22 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
      *
      * @return Returns the current field to allow for chaining.
      */
-    public F render(Supplier<SimpleControl<F>> newValue) {
+    public F render(SimpleControl<F> newValue) {
         renderer = newValue;
+        return (F) this;
+    }
+
+    /**
+     * Sets the control supplier that renders this field.
+     * The supplier is only called when required, i.e., when the GUI is created.
+     *
+     * @param newValue
+     *              The new control supplier to render the field.
+     *
+     * @return Returns the current field to allow for chaining.
+     */
+    public F render(Supplier<SimpleControl<F>> newValue) {
+        rendererSupplier = newValue;
         return (F) this;
     }
 
@@ -795,7 +810,11 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
     }
 
     public SimpleControl<F> getRenderer() {
-        return renderer.get();
+        if (renderer == null) {
+            renderer = rendererSupplier.get();
+        }
+
+        return renderer;
     }
 
     public List<String> getErrorMessages() {

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/Field.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/Field.java
@@ -46,6 +46,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /**
@@ -144,7 +145,7 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
      */
     protected TranslationService translationService;
 
-    protected SimpleControl<F> renderer;
+    protected Supplier<SimpleControl<F>> renderer;
 
     protected final Map<EventType<FieldEvent>,List<EventHandler<? super FieldEvent>>> eventHandlers = new ConcurrentHashMap<>();
 
@@ -628,7 +629,7 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
      *
      * @return Returns the current field to allow for chaining.
      */
-    public F render(SimpleControl<F> newValue) {
+    public F render(Supplier<SimpleControl<F>> newValue) {
         renderer = newValue;
         return (F) this;
     }
@@ -794,7 +795,7 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
     }
 
     public SimpleControl<F> getRenderer() {
-        return renderer;
+        return renderer.get();
     }
 
     public List<String> getErrorMessages() {

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/IntegerField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/IntegerField.java
@@ -53,7 +53,7 @@ public class IntegerField extends DataField<IntegerProperty, Integer, IntegerFie
                 return Integer.parseInt(string);
             }
         };
-        renderer = new SimpleIntegerControl();
+        renderer = () -> new SimpleIntegerControl();
 
         userInput.set(stringConverter.toString(value.getValue()));
     }

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/IntegerField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/IntegerField.java
@@ -53,7 +53,7 @@ public class IntegerField extends DataField<IntegerProperty, Integer, IntegerFie
                 return Integer.parseInt(string);
             }
         };
-        renderer = () -> new SimpleIntegerControl();
+        rendererSupplier = () -> new SimpleIntegerControl();
 
         userInput.set(stringConverter.toString(value.getValue()));
     }

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/MultiSelectionField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/MultiSelectionField.java
@@ -100,7 +100,7 @@ public class MultiSelectionField<V> extends SelectionField<V, MultiSelectionFiel
             persistentSelection.clear();
         });
 
-        renderer = () -> new SimpleListViewControl<>();
+        rendererSupplier = () -> new SimpleListViewControl<>();
     }
 
     /**

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/MultiSelectionField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/MultiSelectionField.java
@@ -100,7 +100,7 @@ public class MultiSelectionField<V> extends SelectionField<V, MultiSelectionFiel
             persistentSelection.clear();
         });
 
-        renderer = new SimpleListViewControl<>();
+        renderer = () -> new SimpleListViewControl<>();
     }
 
     /**

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/PasswordField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/PasswordField.java
@@ -53,7 +53,7 @@ public class PasswordField extends DataField<StringProperty, String, PasswordFie
                 return string;
             }
         };
-        renderer = () -> new SimplePasswordControl();
+        rendererSupplier = () -> new SimplePasswordControl();
 
         userInput.set(stringConverter.toString(value.getValue()));
     }

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/PasswordField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/PasswordField.java
@@ -53,7 +53,7 @@ public class PasswordField extends DataField<StringProperty, String, PasswordFie
                 return string;
             }
         };
-        renderer = new SimplePasswordControl();
+        renderer = () -> new SimplePasswordControl();
 
         userInput.set(stringConverter.toString(value.getValue()));
     }

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/SingleSelectionField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/SingleSelectionField.java
@@ -96,7 +96,7 @@ public class SingleSelectionField<V> extends SelectionField<V, SingleSelectionFi
             persistentSelection.setValue(null);
         });
 
-        renderer = new SimpleComboBoxControl<>();
+        renderer = () -> new SimpleComboBoxControl<>();
     }
 
     /**

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/SingleSelectionField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/SingleSelectionField.java
@@ -96,7 +96,7 @@ public class SingleSelectionField<V> extends SelectionField<V, SingleSelectionFi
             persistentSelection.setValue(null);
         });
 
-        renderer = () -> new SimpleComboBoxControl<>();
+        rendererSupplier = () -> new SimpleComboBoxControl<>();
     }
 
     /**

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/StringField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/StringField.java
@@ -56,7 +56,7 @@ public class StringField extends DataField<StringProperty, String, StringField> 
                 return string;
             }
         };
-        renderer = () -> new SimpleTextControl();
+        rendererSupplier = () -> new SimpleTextControl();
 
         userInput.set(stringConverter.toString(value.getValue()));
     }

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/StringField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/StringField.java
@@ -56,7 +56,7 @@ public class StringField extends DataField<StringProperty, String, StringField> 
                 return string;
             }
         };
-        renderer = new SimpleTextControl();
+        renderer = () -> new SimpleTextControl();
 
         userInput.set(stringConverter.toString(value.getValue()));
     }

--- a/formsfx-demo/src/main/java/com/dlsc/formsfx/demo/model/DemoModel.java
+++ b/formsfx-demo/src/main/java/com/dlsc/formsfx/demo/model/DemoModel.java
@@ -113,7 +113,7 @@ public final class DemoModel {
                                 .required("required_error_message")
                                 .label("driving_label")
                                 .span(ColSpan.HALF)
-                                .render(new SimpleRadioButtonControl<>()),
+                                .render(() -> new SimpleRadioButtonControl<>()),
                         Field.ofStringType(country.timeZoneProperty())
                                 .label("time_zone_label")
                                 .placeholder("time_zone_placeholder")
@@ -142,7 +142,7 @@ public final class DemoModel {
                                 .label("continent_label")
                                 .required("required_error_message")
                                 .span(ColSpan.HALF)
-                                .render(new SimpleCheckBoxControl<>()),
+                                .render(() -> new SimpleCheckBoxControl<>()),
                         Field.ofMultiSelectionType(country.allCitiesProperty(), country.germanCitiesProperty())
                                 .label("german_cities_label")
                                 .span(ColSpan.HALF),


### PR DESCRIPTION
I'm using PreferencesFX in my application and I'm very happy with it. However, it is a special kind of application that should also be able to work without any GUI support, i.e. it should still work when the JavaFX platform can't be initialized. One major hurdle for that is that the PreferencesFX renderers are are created instantly when creating the field, even though they don't have to.
This instant initialization forces a platform initialization, which fails on headless systems and causes the preferences to not be loaded.

This PR delays the renderer instantiation until it is actually needed. Obviously, this is only a basic pull request meant to get some feedback. If a change of that form would be actually accepted, I would augment this PR to also support the normal renderer initialization such that the interface is fully compatible with previous versions of FormsFX and also create a similar PreferencesFX PR.