### PR TITLE
Feat/field visibility

### DIFF
--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/BooleanField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/BooleanField.java
@@ -9,9 +9,9 @@ package com.dlsc.formsfx.model.structure;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -37,12 +37,10 @@ public class BooleanField extends DataField<BooleanProperty, Boolean, BooleanFie
     /**
      * The constructor of {@code BooleanField}.
      *
-     * @param valueProperty
-     *              The property that is used to store the current valid value
-     *              of the field.
-     * @param persistentValueProperty
-     *              The property that is used to store the latest persisted
-     *              value of the field.
+     * @param valueProperty           The property that is used to store the current valid value
+     *                                of the field.
+     * @param persistentValueProperty The property that is used to store the latest persisted
+     *                                value of the field.
      */
     protected BooleanField(SimpleBooleanProperty valueProperty, SimpleBooleanProperty persistentValueProperty) {
         super(valueProperty, persistentValueProperty);
@@ -53,9 +51,10 @@ public class BooleanField extends DataField<BooleanProperty, Boolean, BooleanFie
                 return Boolean.parseBoolean(string);
             }
         };
-        rendererSupplier = () -> new SimpleBooleanControl();
+        rendererSupplier = SimpleBooleanControl::new;
 
         userInput.set(stringConverter.toString(value.getValue()));
+        blockLabel.set(false);
     }
 
     /**

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/DataField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/DataField.java
@@ -109,10 +109,10 @@ public abstract class DataField<P extends Property, V, F extends Field<F>> exten
      *                                of the field.
      * @param persistentValueProperty The property that is used to store the latest persisted
      *                                value of the field.
-     * @see Field::ofStringType
-     * @see Field::ofIntegerType
-     * @see Field::ofDoubleType
-     * @see Field::ofBooleanType
+     * @see Field#ofStringType
+     * @see Field#ofIntegerType
+     * @see Field#ofDoubleType
+     * @see Field#ofBooleanType
      */
     protected DataField(P valueProperty, P persistentValueProperty) {
         value = valueProperty;

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/DataField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/DataField.java
@@ -9,9 +9,9 @@ package com.dlsc.formsfx.model.structure;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -31,6 +31,7 @@ import javafx.beans.binding.Bindings;
 import javafx.beans.property.Property;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
+import javafx.beans.value.ObservableBooleanValue;
 import javafx.util.StringConverter;
 
 import java.util.ArrayList;
@@ -46,21 +47,22 @@ import java.util.stream.Collectors;
  * @author Rinesch Murugathas
  */
 public abstract class DataField<P extends Property, V, F extends Field<F>> extends Field<F> {
-  
+
     /**
      * Every field tracks its value in multiple ways.
-     *
+     * <p>
      * - The user input is bound to a specific control's input value and is a
-     *   1-to-1 representation of what the user enters.
+     * 1-to-1 representation of what the user enters.
      * - The value is the last valid value entered by the user. This means that
-     *   the value passes the type transformation of the concrete field and all
-     *   user-defined validations.
+     * the value passes the type transformation of the concrete field and all
+     * user-defined validations.
      * - The persistent value is the value that was last saved on the field. It
-     *   is the responsibility of the form creator to persist the field values
-     *   at the correct time.
+     * is the responsibility of the form creator to persist the field values
+     * at the correct time.
      */
     protected final P value;
     protected final P persistentValue;
+    protected V invisibleValue;
     protected final StringProperty userInput = new SimpleStringProperty("");
 
     /**
@@ -72,6 +74,7 @@ public abstract class DataField<P extends Property, V, F extends Field<F>> exten
     /**
      * The value transformer is responsible for transforming the user input
      * string to the specific type of the field's value.
+     *
      * @deprecated Use DataField#stringConverter instead.
      */
     @Deprecated
@@ -86,7 +89,7 @@ public abstract class DataField<P extends Property, V, F extends Field<F>> exten
 
     /**
      * The format error is displayed when the value transformation fails.
-     *
+     * <p>
      * This property is translatable if a {@link TranslationService} is set on
      * the containing form.
      */
@@ -102,17 +105,14 @@ public abstract class DataField<P extends Property, V, F extends Field<F>> exten
      * Internal constructor for the {@code DataField} class. To create new
      * elements, see the static factory methods in {@code Field}.
      *
+     * @param valueProperty           The property that is used to store the current valid value
+     *                                of the field.
+     * @param persistentValueProperty The property that is used to store the latest persisted
+     *                                value of the field.
      * @see Field::ofStringType
      * @see Field::ofIntegerType
      * @see Field::ofDoubleType
      * @see Field::ofBooleanType
-     *
-     * @param valueProperty
-     *              The property that is used to store the current valid value
-     *              of the field.
-     * @param persistentValueProperty
-     *              The property that is used to store the latest persisted
-     *              value of the field.
      */
     protected DataField(P valueProperty, P persistentValueProperty) {
         value = valueProperty;
@@ -123,7 +123,7 @@ public abstract class DataField<P extends Property, V, F extends Field<F>> exten
         // until Field::persist or Field::reset are called or the value is back
         // to the persistent value.
 
-        changed.bind(Bindings.createBooleanBinding(() -> !stringConverter.toString((V) persistentValue.getValue()).equals(userInput.getValue()), userInput, persistentValue));
+        changed.bind(Bindings.createBooleanBinding(() -> isVisible() && !stringConverter.toString((V) persistentValue.getValue()).equals(userInput.getValue()), userInput, persistentValue, visibleProperty()));
 
         // Whenever one of the translatable elements' keys change, update the
         // displayed value based on the new translation.
@@ -136,6 +136,12 @@ public abstract class DataField<P extends Property, V, F extends Field<F>> exten
         userInput.addListener((observable, oldValue, newValue) -> {
             if (validate()) {
                 value.setValue(stringConverter.fromString(newValue));
+            }
+        });
+
+        visible.addListener((ob, ov, nv) -> {
+            if (!nv) {
+                value.setValue(invisibleValue);
             }
         });
     }
@@ -163,10 +169,8 @@ public abstract class DataField<P extends Property, V, F extends Field<F>> exten
     /**
      * Sets the string converter for the current field.
      *
-     * @param newValue
-     *              The string converter that transforms the user input string to
-     *              the field's underlying value and back.
-     *
+     * @param newValue The string converter that transforms the user input string to
+     *                 the field's underlying value and back.
      * @return Returns the current field to allow for chaining.
      */
     public F format(StringConverter<V> newValue) {
@@ -179,13 +183,10 @@ public abstract class DataField<P extends Property, V, F extends Field<F>> exten
      * Applies a new string converter that converts the entered string input
      * to a concrete value.
      *
-     * @param newValue
-     *              The string converter that transforms the user input string to
-     *              the field's underlying value and back.
-     * @param errorMessage
-     *              The error message to display if the transformation was
-     *              unsuccessful.
-     *
+     * @param newValue     The string converter that transforms the user input string to
+     *                     the field's underlying value and back.
+     * @param errorMessage The error message to display if the transformation was
+     *                     unsuccessful.
      * @return Returns the current field to allow for chaining.
      */
     public F format(StringConverter<V> newValue, String errorMessage) {
@@ -204,10 +205,8 @@ public abstract class DataField<P extends Property, V, F extends Field<F>> exten
     /**
      * Sets the value transformer for the current field.
      *
-     * @param newValue
-     *              The value transformer that parses the user input string to
-     *              the field's underlying value.
-     *
+     * @param newValue The value transformer that parses the user input string to
+     *                 the field's underlying value.
      * @return Returns the current field to allow for chaining.
      * @deprecated Use format(StringConverter) instead
      */
@@ -222,13 +221,10 @@ public abstract class DataField<P extends Property, V, F extends Field<F>> exten
      * Applies a new value transformer that converts the entered string input
      * to a concrete value.
      *
-     * @param newValue
-     *              The new value transformer. Takes a string as an input and
-     *              returns the concrete type.
-     * @param errorMessage
-     *              The error message to display if the transformation was
-     *              unsuccessful.
-     *
+     * @param newValue     The new value transformer. Takes a string as an input and
+     *                     returns the concrete type.
+     * @param errorMessage The error message to display if the transformation was
+     *                     unsuccessful.
      * @return Returns the current field to allow for chaining.
      * @deprecated Use format(StringConverter, errorMessage) instead
      */
@@ -250,10 +246,8 @@ public abstract class DataField<P extends Property, V, F extends Field<F>> exten
      * Adds an error message to handle formatting errors with the default
      * value transformers.
      *
-     * @param errorMessage
-     *              The error message to display if the transformation was
-     *              unsuccessful.
-     *
+     * @param errorMessage The error message to display if the transformation was
+     *                     unsuccessful.
      * @return Returns the current field to allow for chaining.
      */
     public F format(String errorMessage) {
@@ -271,11 +265,9 @@ public abstract class DataField<P extends Property, V, F extends Field<F>> exten
      * Sets the list of validators for the current field. This overrides all
      * validators that have previously been added.
      *
-     * @param newValue
-     *              The validators that are to be used for validating this
-     *              field. Limited to validators that are able to handle the
-     *              field's underlying type.
-     *
+     * @param newValue The validators that are to be used for validating this
+     *                 field. Limited to validators that are able to handle the
+     *                 field's underlying type.
      * @return Returns the current field to allow for chaining.
      */
     @SafeVarargs
@@ -290,9 +282,7 @@ public abstract class DataField<P extends Property, V, F extends Field<F>> exten
     /**
      * Binds the given property with the field.
      *
-     * @param binding
-     *          The property to be bound with.
-     *
+     * @param binding The property to be bound with.
      * @return Returns the current field to allow for chaining.
      */
     public F bind(P binding) {
@@ -305,9 +295,7 @@ public abstract class DataField<P extends Property, V, F extends Field<F>> exten
     /**
      * Unbinds the given property with the field.
      *
-     * @param binding
-     *          The property to be unbound with.
-     *
+     * @param binding The property to be unbound with.
      * @return Returns the current field to allow for chaining.
      */
     public F unbind(P binding) {
@@ -355,15 +343,23 @@ public abstract class DataField<P extends Property, V, F extends Field<F>> exten
     }
 
     /**
-     * Validates that the new field input matches the required condition.
+     * Validates that the new field input matches the required condition, if the field is visible.
      *
-     * @param newValue
-     *              The new value to check for the required state.
-     *
+     * @param newValue The new value to check for the required state.
      * @return Returns whether the input matches the required condition.
      */
     protected boolean validateRequired(String newValue) {
-        return !isRequired() || (isRequired() && !newValue.isEmpty());
+        return isVisible() && (!isRequired() || (isRequired() && !newValue.isEmpty()));
+    }
+
+    public F visibility(boolean defaultVisibility, V invisibleValue) {
+        this.invisibleValue = invisibleValue;
+        return super.visibility(defaultVisibility);
+    }
+
+    public F visibility(ObservableBooleanValue visibility, V invisibleValue) {
+        this.invisibleValue = invisibleValue;
+        return super.visibility(visibility);
     }
 
     /**
@@ -375,6 +371,14 @@ public abstract class DataField<P extends Property, V, F extends Field<F>> exten
      */
     public boolean validate() {
         String newValue = userInput.getValue();
+
+        if (!isVisible()) {
+            valid.set(true);
+            errorMessages.clear();
+            errorMessageKeys.clear();
+            valid.set(true);
+            return true;
+        }
 
         if (!validateRequired(newValue)) {
             if (isI18N() && !requiredErrorKey.get().isEmpty()) {

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/DataField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/DataField.java
@@ -31,7 +31,6 @@ import javafx.beans.binding.Bindings;
 import javafx.beans.property.Property;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
-import javafx.beans.value.ObservableBooleanValue;
 import javafx.util.StringConverter;
 
 import java.util.ArrayList;
@@ -142,6 +141,7 @@ public abstract class DataField<P extends Property, V, F extends Field<F>> exten
             if (!nv) {
                 reset();
             }
+            validate();
         });
     }
 

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/DataField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/DataField.java
@@ -62,7 +62,6 @@ public abstract class DataField<P extends Property, V, F extends Field<F>> exten
      */
     protected final P value;
     protected final P persistentValue;
-    protected V invisibleValue;
     protected final StringProperty userInput = new SimpleStringProperty("");
 
     /**
@@ -141,7 +140,7 @@ public abstract class DataField<P extends Property, V, F extends Field<F>> exten
 
         visible.addListener((ob, ov, nv) -> {
             if (!nv) {
-                value.setValue(invisibleValue);
+                reset();
             }
         });
     }
@@ -350,16 +349,6 @@ public abstract class DataField<P extends Property, V, F extends Field<F>> exten
      */
     protected boolean validateRequired(String newValue) {
         return isVisible() && (!isRequired() || (isRequired() && !newValue.isEmpty()));
-    }
-
-    public F visibility(boolean defaultVisibility, V invisibleValue) {
-        this.invisibleValue = invisibleValue;
-        return super.visibility(defaultVisibility);
-    }
-
-    public F visibility(ObservableBooleanValue visibility, V invisibleValue) {
-        this.invisibleValue = invisibleValue;
-        return super.visibility(visibility);
     }
 
     /**

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/Element.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/Element.java
@@ -9,9 +9,9 @@ package com.dlsc.formsfx.model.structure;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,12 +21,8 @@ package com.dlsc.formsfx.model.structure;
  */
 
 import com.dlsc.formsfx.view.util.ColSpan;
-import javafx.beans.property.IntegerProperty;
-import javafx.beans.property.ListProperty;
-import javafx.beans.property.SimpleIntegerProperty;
-import javafx.beans.property.SimpleListProperty;
-import javafx.beans.property.SimpleStringProperty;
-import javafx.beans.property.StringProperty;
+import javafx.beans.property.*;
+import javafx.beans.value.ObservableBooleanValue;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 
@@ -42,13 +38,15 @@ public abstract class Element<E extends Element<E>> {
     protected final StringProperty id = new SimpleStringProperty(UUID.randomUUID().toString());
     protected final ListProperty<String> styleClass = new SimpleListProperty<>(FXCollections.observableArrayList());
     protected final IntegerProperty span = new SimpleIntegerProperty(12);
+    /**
+     * Whether the element is visible or not.
+     */
+    protected final BooleanProperty visible = new SimpleBooleanProperty(true);
 
     /**
      * Sets the id property of the current field.
      *
-     * @param newValue
-     *              The new value for the id property.
-     *
+     * @param newValue The new value for the id property.
      * @return Returns the current field to allow for chaining.
      */
     public E id(String newValue) {
@@ -59,9 +57,7 @@ public abstract class Element<E extends Element<E>> {
     /**
      * Sets the style classes for the current field.
      *
-     * @param newValue
-     *              The new style classes.
-     *
+     * @param newValue The new style classes.
      * @return Returns the current field to allow for chaining.
      */
     public E styleClass(String... newValue) {
@@ -70,11 +66,27 @@ public abstract class Element<E extends Element<E>> {
     }
 
     /**
+     * Sets the visibility of this field.
+     *
+     * @param visibility An observable boolean value which indicates whether the field should be rendered and evaluated during validation
+     * @return The current field to allow for chaining.
+     */
+    public E visibility(ObservableBooleanValue visibility) {
+        if (visible.isBound()) visible.unbind();
+        if (visibility != null)
+            visible.bind(visibility);
+        return (E) this;
+    }
+
+    public E visibility(boolean defaultVisibility) {
+        visible.set(defaultVisibility);
+        return (E) this;
+    }
+
+    /**
      * Sets the amount of columns the field takes up inside the section grid.
      *
-     * @param newValue
-     *              The new number of columns.
-     *
+     * @param newValue The new number of columns.
      * @return Returns the current field to allow for chaining.
      */
     public E span(int newValue) {
@@ -85,9 +97,7 @@ public abstract class Element<E extends Element<E>> {
     /**
      * Sets the amount of columns the field takes up inside the section grid.
      *
-     * @param newValue
-     *              The new span fraction.
-     *
+     * @param newValue The new span fraction.
      * @return Returns the current field to allow for chaining.
      */
     public E span(ColSpan newValue) {
@@ -117,5 +127,13 @@ public abstract class Element<E extends Element<E>> {
 
     public ListProperty<String> styleClassProperty() {
         return styleClass;
+    }
+
+    public boolean isVisible() {
+        return visible.get();
+    }
+
+    public BooleanProperty visibleProperty() {
+        return visible;
     }
 }

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/Element.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/Element.java
@@ -42,6 +42,7 @@ public abstract class Element<E extends Element<E>> {
      * Whether the element is visible or not.
      */
     protected final BooleanProperty visible = new SimpleBooleanProperty(true);
+    protected final BooleanProperty blockLabel = new SimpleBooleanProperty(true);
 
     /**
      * Sets the id property of the current field.
@@ -75,6 +76,11 @@ public abstract class Element<E extends Element<E>> {
         if (visible.isBound()) visible.unbind();
         if (visibility != null)
             visible.bind(visibility);
+        return (E) this;
+    }
+
+    public E blockedLabel(boolean v) {
+        blockLabel.set(v);
         return (E) this;
     }
 
@@ -135,5 +141,9 @@ public abstract class Element<E extends Element<E>> {
 
     public BooleanProperty visibleProperty() {
         return visible;
+    }
+
+    public boolean isBlockLabel() {
+        return blockLabel.get();
     }
 }

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/Element.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/Element.java
@@ -73,7 +73,10 @@ public abstract class Element<E extends Element<E>> {
      * @return The current field to allow for chaining.
      */
     public E visibility(ObservableBooleanValue visibility) {
-        if (visible.isBound()) visible.unbind();
+        if (visible.isBound()) {
+            visible.unbind();
+            visible.set(true);
+        }
         if (visibility != null)
             visible.bind(visibility);
         return (E) this;

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/Field.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/Field.java
@@ -9,9 +9,9 @@ package com.dlsc.formsfx.model.structure;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,6 +26,7 @@ import com.dlsc.formsfx.model.util.TranslationService;
 import com.dlsc.formsfx.view.controls.SimpleControl;
 import javafx.beans.InvalidationListener;
 import javafx.beans.property.*;
+import javafx.beans.value.ObservableBooleanValue;
 import javafx.collections.FXCollections;
 
 import java.time.LocalDate;
@@ -53,7 +54,7 @@ import java.util.stream.Collectors;
  * This class provides the base implementation for a FormsFX field. It is not
  * meant to be used directly, but instead acts as a base for concrete
  * implementations.
- *
+ * <p>
  * A field is the smallest unit of the form. It contains only the value and
  * relevant information.
  *
@@ -65,7 +66,7 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
     /**
      * The label acts as a description for the field. It is always visible to
      * the user and tells them what should be entered into the field.
-     *
+     * <p>
      * This property is translatable if a {@link TranslationService} is set on
      * the containing form.
      */
@@ -75,7 +76,7 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
     /**
      * The tooltip is an extension of the label. It contains additional
      * information about the contained data that is only contextually visible.
-     *
+     * <p>
      * This property is translatable if a {@link TranslationService} is set on
      * the containing form.
      */
@@ -85,7 +86,7 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
     /**
      * The placeholder is only visible in an empty field. It provides a hint to
      * the user about what should be entered into the field.
-     *
+     * <p>
      * This property is translatable if a {@link TranslationService} is set on
      * the containing form.
      */
@@ -118,7 +119,7 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
     /**
      * The results of the field's validation is stored in this property. After
      * every validation, the results are updated and reflected in this property.
-     *
+     * <p>
      * This property is translatable if a {@link TranslationService} is set on
      * the containing form.
      */
@@ -127,7 +128,7 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
 
     /**
      * Additional descriptions for the field's label and value are stored in these properties.
-     *
+     * <p>
      * These properties are translatable if a {@link TranslationService} is set on
      * the containing form.
      */
@@ -148,7 +149,7 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
     protected SimpleControl<F> renderer;
     protected Supplier<SimpleControl<F>> rendererSupplier;
 
-    protected final Map<EventType<FieldEvent>,List<EventHandler<? super FieldEvent>>> eventHandlers = new ConcurrentHashMap<>();
+    protected final Map<EventType<FieldEvent>, List<EventHandler<? super FieldEvent>>> eventHandlers = new ConcurrentHashMap<>();
 
     /**
      * With the continuous binding mode, values are always directly persisted
@@ -200,9 +201,7 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
     /**
      * Creates a new {@link PasswordField} with the given default value.
      *
-     * @param defaultValue
-     *              The initial value and persistent value of the field.
-     *
+     * @param defaultValue The initial value and persistent value of the field.
      * @return Returns a new {@link PasswordField}.
      */
     public static PasswordField ofPasswordType(String defaultValue) {
@@ -212,9 +211,7 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
     /**
      * Creates a new {@link PasswordField} with the given property.
      *
-     * @param binding
-     *          The property from the model to be bound with.
-     *
+     * @param binding The property from the model to be bound with.
      * @return Returns a new {@link PasswordField}.
      */
     public static PasswordField ofPasswordType(StringProperty binding) {
@@ -224,9 +221,7 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
     /**
      * Creates a new {@link StringField} with the given default value.
      *
-     * @param defaultValue
-     *              The initial value and persistent value of the field.
-     *
+     * @param defaultValue The initial value and persistent value of the field.
      * @return Returns a new {@link StringField}.
      */
     public static StringField ofStringType(String defaultValue) {
@@ -236,9 +231,7 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
     /**
      * Creates a new {@link StringField} with the given property.
      *
-     * @param binding
-     *          The property from the model to be bound with.
-     *
+     * @param binding The property from the model to be bound with.
      * @return Returns a new {@link StringField}.
      */
     public static StringField ofStringType(StringProperty binding) {
@@ -248,9 +241,7 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
     /**
      * Creates a new {@link DoubleField} with the given default value.
      *
-     * @param defaultValue
-     *              The initial value and persistent value of the field.
-     *
+     * @param defaultValue The initial value and persistent value of the field.
      * @return Returns a new {@link DoubleField}.
      */
     public static DoubleField ofDoubleType(double defaultValue) {
@@ -260,9 +251,7 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
     /**
      * Creates a new {@link DoubleField} with the given property.
      *
-     * @param binding
-     *          The property from the model to be bound with.
-     *
+     * @param binding The property from the model to be bound with.
      * @return Returns a new {@link DoubleField}.
      */
     public static DoubleField ofDoubleType(DoubleProperty binding) {
@@ -272,9 +261,7 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
     /**
      * Creates a new {@link IntegerField} with the given default value.
      *
-     * @param defaultValue
-     *              The initial value and persistent value of the field.
-     *
+     * @param defaultValue The initial value and persistent value of the field.
      * @return Returns a new {@link IntegerField}.
      */
     public static IntegerField ofIntegerType(int defaultValue) {
@@ -284,9 +271,7 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
     /**
      * Creates a new {@link IntegerField} with the given property.
      *
-     * @param binding
-     *          The property from the model to be bound with.
-     *
+     * @param binding The property from the model to be bound with.
      * @return Returns a new {@link IntegerField}.
      */
     public static IntegerField ofIntegerType(IntegerProperty binding) {
@@ -296,9 +281,7 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
     /**
      * Creates a new {@link BooleanField} with the given default value.
      *
-     * @param defaultValue
-     *              The initial value and persistent value of the field.
-     *
+     * @param defaultValue The initial value and persistent value of the field.
      * @return Returns a new {@link BooleanField}.
      */
     public static BooleanField ofBooleanType(boolean defaultValue) {
@@ -308,9 +291,7 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
     /**
      * Creates a new {@link BooleanField} with the given property.
      *
-     * @param binding
-     *          The property from the model to be bound with.
-     *
+     * @param binding The property from the model to be bound with.
      * @return Returns a new {@link BooleanField}.
      */
     public static BooleanField ofBooleanType(BooleanProperty binding) {
@@ -321,11 +302,8 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
      * Creates a new {@link MultiSelectionField} with the given items and a
      * pre-defined selection.
      *
-     * @param items
-     *              The list of available items on the field.
-     * @param selection
-     *              The pre-defined indices of the selected items.
-     *
+     * @param items     The list of available items on the field.
+     * @param selection The pre-defined indices of the selected items.
      * @return Returns a new {@link MultiSelectionField}.
      */
     public static <T> MultiSelectionField<T> ofMultiSelectionType(List<T> items, List<Integer> selection) {
@@ -336,9 +314,7 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
      * Creates a new {@link MultiSelectionField} with the given items and no
      * pre-defined selection.
      *
-     * @param items
-     *              The list of available items on the field.
-     *
+     * @param items The list of available items on the field.
      * @return Returns a new {@link MultiSelectionField}.
      */
     public static <T> MultiSelectionField<T> ofMultiSelectionType(List<T> items) {
@@ -349,12 +325,8 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
      * Creates a new {@link MultiSelectionField} with the given properties for
      * items and selection.
      *
-     * @param itemsBinding
-     *          The items property to be bound with.
-     *
-     * @param selectionBinding
-     *          The selection property to be bound with.
-     *
+     * @param itemsBinding     The items property to be bound with.
+     * @param selectionBinding The selection property to be bound with.
      * @return Returns a new {@link MultiSelectionField}.
      */
     public static <T> MultiSelectionField<T> ofMultiSelectionType(ListProperty<T> itemsBinding, ListProperty<T> selectionBinding) {
@@ -365,11 +337,8 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
      * Creates a new {@link SingleSelectionField} with the given items and a
      * pre-defined selection.
      *
-     * @param items
-     *              The list of available items on the field.
-     * @param selection
-     *              The pre-defined index of the selected item.
-     *
+     * @param items     The list of available items on the field.
+     * @param selection The pre-defined index of the selected item.
      * @return Returns a new {@link SingleSelectionField}.
      */
     public static <T> SingleSelectionField<T> ofSingleSelectionType(List<T> items, int selection) {
@@ -380,9 +349,7 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
      * Creates a new {@link SingleSelectionField} with the given items and no
      * pre-defined selection.
      *
-     * @param items
-     *              The list of available items on the field.
-     *
+     * @param items The list of available items on the field.
      * @return Returns a new {@link SingleSelectionField}.
      */
     public static <T> SingleSelectionField<T> ofSingleSelectionType(List<T> items) {
@@ -393,12 +360,8 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
      * Creates a new {@link SingleSelectionField} with the given properties for
      * items and selection.
      *
-     * @param itemsBinding
-     *          The items property to be bound with.
-     *
-     * @param selectionBinding
-     *          The selection property to be bound with.
-     *
+     * @param itemsBinding     The items property to be bound with.
+     * @param selectionBinding The selection property to be bound with.
      * @return Returns a new {@link SingleSelectionField}.
      */
     public static <T> SingleSelectionField<T> ofSingleSelectionType(ListProperty<T> itemsBinding, ObjectProperty<T> selectionBinding) {
@@ -429,9 +392,7 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
      * Sets the required property to for the current field without providing an
      * error message.
      *
-     * @param newValue
-     *              The new state of the required property.
-     *
+     * @param newValue The new state of the required property.
      * @return Returns the current field to allow for chaining.
      */
     public F required(boolean newValue) {
@@ -444,9 +405,7 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
     /**
      * Sets the required property to true for the current field.
      *
-     * @param errorMessage
-     *              The error message if the field is not filled in.
-     *
+     * @param errorMessage The error message if the field is not filled in.
      * @return Returns the current field to allow for chaining.
      */
     public F required(String errorMessage) {
@@ -466,9 +425,7 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
     /**
      * Sets the editable property of the current field.
      *
-     * @param newValue
-     *              The new value for the editable property.
-     *
+     * @param newValue The new value for the editable property.
      * @return Returns the current field to allow for chaining.
      */
     public F editable(boolean newValue) {
@@ -479,13 +436,10 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
     /**
      * Sets the label property of the current field.
      *
-     * @param newValue
-     *              The new value for the label property. This can be the label
-     *              itself or a key that is then used for translation.
-     *
-     * @see TranslationService
-     *
+     * @param newValue The new value for the label property. This can be the label
+     *                 itself or a key that is then used for translation.
      * @return Returns the current field to allow for chaining.
+     * @see TranslationService
      */
     public F label(String newValue) {
         if (isI18N()) {
@@ -500,10 +454,7 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
     /**
      * Sets the label description property of the current field.
      *
-     * @param newValue
-     *              The new value for the label description property.
-     *
-     *
+     * @param newValue The new value for the label description property.
      * @return Returns the current field to allow for chaining.
      */
     public F labelDescription(Node newValue) {
@@ -518,15 +469,12 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
     /**
      * Sets the label description property of the current field.
      *
-     * @param newValue
-     *              The new value for the label description property,
-     *              wrapped with a {@code Text}.
-     *
-     *
+     * @param newValue The new value for the label description property,
+     *                 wrapped with a {@code Text}.
      * @return Returns the current field to allow for chaining.
      */
     public F labelDescription(String newValue) {
-        if(isI18N()) {
+        if (isI18N()) {
             labelDescriptionKey.set(newValue);
         } else if (newValue != null) {
             labelDescription = asLabel(newValue, LABEL_DESCRIPTION_STYLE_CLASS);
@@ -538,10 +486,7 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
     /**
      * Sets the value description property of the current field.
      *
-     * @param newValue
-     *              The new value for the field description property.
-     *
-     *
+     * @param newValue The new value for the field description property.
      * @return Returns the current field to allow for chaining.
      */
     public F valueDescription(Node newValue) {
@@ -556,15 +501,12 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
     /**
      * Sets the value description property of the current field.
      *
-     * @param newValue
-     *              The new value for the field description property,
-     *              wrapped with a {@code Text}.
-     *
-     *
+     * @param newValue The new value for the field description property,
+     *                 wrapped with a {@code Text}.
      * @return Returns the current field to allow for chaining.
      */
     public F valueDescription(String newValue) {
-        if(isI18N()) {
+        if (isI18N()) {
             valueDescriptionKey.set(newValue);
         } else if (newValue != null) {
             valueDescription = asLabel(newValue, VALUE_DESCRIPTION_STYLE_CLASS);
@@ -583,13 +525,10 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
     /**
      * Sets the tooltip property of the current field.
      *
-     * @param newValue
-     *              The new value for the tooltip property. This can be the
-     *              label itself or a key that is then used for translation.
-     *
-     * @see TranslationService
-     *
+     * @param newValue The new value for the tooltip property. This can be the
+     *                 label itself or a key that is then used for translation.
      * @return Returns the current field to allow for chaining.
+     * @see TranslationService
      */
     public F tooltip(String newValue) {
         if (isI18N()) {
@@ -604,13 +543,10 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
     /**
      * Sets the placeholder property of the current field.
      *
-     * @param newValue
-     *              The new value for the placeholder property. This can be the
-     *              label itself or a key that is then used for translation.
-     *
-     * @see TranslationService
-     *
+     * @param newValue The new value for the placeholder property. This can be the
+     *                 label itself or a key that is then used for translation.
      * @return Returns the current field to allow for chaining.
+     * @see TranslationService
      */
     public F placeholder(String newValue) {
         if (isI18N()) {
@@ -625,9 +561,7 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
     /**
      * Sets the control that renders this field.
      *
-     * @param newValue
-     *              The new control to render the field.
-     *
+     * @param newValue The new control to render the field.
      * @return Returns the current field to allow for chaining.
      */
     public F render(SimpleControl<F> newValue) {
@@ -639,9 +573,7 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
      * Sets the control supplier that renders this field.
      * The supplier is only called when required, i.e., when the GUI is created.
      *
-     * @param newValue
-     *              The new control supplier to render the field.
-     *
+     * @param newValue The new control supplier to render the field.
      * @return Returns the current field to allow for chaining.
      */
     public F render(Supplier<SimpleControl<F>> newValue) {
@@ -653,8 +585,7 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
      * Activates or deactivates the {@code bindingModeListener} based on the
      * given {@code BindingMode}.
      *
-     * @param newValue
-     *              The new binding mode for the current field.
+     * @param newValue The new binding mode for the current field.
      */
     public abstract void setBindingMode(BindingMode newValue);
 
@@ -666,8 +597,7 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
      * This internal method is called by the containing section when a new
      * translation has been added to the form.
      *
-     * @param newValue
-     *              The new service to use for translating translatable values.
+     * @param newValue The new service to use for translating translatable values.
      */
     public void translate(TranslationService newValue) {
         translationService = newValue;
@@ -692,10 +622,8 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
     /**
      * Updates a displayable field property to include translated text.
      *
-     * @param displayProperty
-     *              The property that is displayed to the user.
-     * @param keyProperty
-     *              The internal property that holds the translation key.
+     * @param displayProperty The property that is displayed to the user.
+     * @param keyProperty     The internal property that holds the translation key.
      */
     protected void updateElement(StringProperty displayProperty, StringProperty keyProperty) {
 
@@ -714,10 +642,8 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
     /**
      * Updates a displayable field property to include translated text.
      *
-     * @param node
-     *              The property that is displayed to the user.
-     * @param keyProperty
-     *              The internal property that holds the translation key.
+     * @param node        The property that is displayed to the user.
+     * @param keyProperty The internal property that holds the translation key.
      */
     void updateElement(Node node, StringProperty keyProperty) {
 
@@ -742,7 +668,7 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
 
     /**
      * Validates a user input based on the field's value transformer and its
-     * validation rules. Also considers the {@code required} flag. This method
+     * validation rules. Also considers the {@code required} and {@code visible} flag. This method
      * directly updates the {@code valid} property.
      *
      * @return Returns whether the user input is a valid value or not.
@@ -832,7 +758,6 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
      *
      * @param eventType    the type of the events to receive by the handler
      * @param eventHandler the handler to register
-     *
      * @throws NullPointerException if either event type or handler are {@code null}.
      */
     public Field addEventHandler(EventType<FieldEvent> eventType, EventHandler<? super FieldEvent> eventHandler) {
@@ -856,7 +781,6 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
      *
      * @param eventType    the event type from which to unregister
      * @param eventHandler the handler to unregister
-     *
      * @throws NullPointerException if either event type or handler are {@code null}.
      */
     public Field removeEventHandler(EventType<FieldEvent> eventType, EventHandler<? super FieldEvent> eventHandler) {
@@ -886,7 +810,7 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
             }
         }
     }
-  
+
     public Node getLabelDescription() {
         return labelDescription;
     }

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/Field.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/Field.java
@@ -165,12 +165,12 @@ public abstract class Field<F extends Field<F>> extends Element<F> implements Fo
      * Internal constructor for the {@code Field} class. To create new elements,
      * see the static factory methods in this class.
      *
-     * @see Field::ofStringType
-     * @see Field::ofIntegerType
-     * @see Field::ofDoubleType
-     * @see Field::ofBooleanType
-     * @see Field::ofMultiSelectionType
-     * @see Field::ofSingleSelectionType
+     * @see Field#ofStringType
+     * @see Field#ofIntegerType
+     * @see Field#ofDoubleType
+     * @see Field#ofBooleanType
+     * @see Field#ofMultiSelectionType
+     * @see Field#ofSingleSelectionType
      */
     protected Field() {
 

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/Form.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/Form.java
@@ -211,7 +211,7 @@ public class Form {
     /**
      * Persists the values for all elements contained in this form's groups.
      *
-     * @see Field::reset
+     * @see Field#reset
      */
     public void persist() {
         if (!isPersistable()) {
@@ -226,7 +226,7 @@ public class Form {
     /**
      * Resets the values for all elements contained in this form's groups.
      *
-     * @see Field::reset
+     * @see Field#reset
      */
     public void reset() {
         if (!hasChanged()) {

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/Group.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/Group.java
@@ -112,7 +112,7 @@ public class Group {
      * translation has been added to the form. Also applies the translation
      * to all contained elements.
      *
-     * @see Field::translate
+     * @see Field#translate
      *
      * @param newValue
      *              The new service to use for translating translatable values.
@@ -132,7 +132,7 @@ public class Group {
 
     /**
      * Persists the values for all contained elements.
-     * @see Field::persist
+     * @see Field#persist
      */
     public void persist() {
         if (!isValid()) {
@@ -149,7 +149,7 @@ public class Group {
 
     /**
      * Resets the values for all contained elements.
-     * @see Field::reset
+     * @see Field#reset
      */
     public void reset() {
         if (!hasChanged()) {

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/MultiSelectionField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/MultiSelectionField.java
@@ -249,7 +249,7 @@ public class MultiSelectionField<V> extends SelectionField<V, MultiSelectionFiel
      * {@inheritDoc}
      */
     protected boolean validateRequired() {
-        return !isRequired() || (isRequired() && selection.size() > 0);
+        return !isVisible() || !isRequired() || (isRequired() && selection.size() > 0);
     }
 
     /**
@@ -260,7 +260,6 @@ public class MultiSelectionField<V> extends SelectionField<V, MultiSelectionFiel
      * @return Returns whether the user selection is a valid value or not.
      */
     public boolean validate() {
-
         if (!isVisible()) {
             errorMessages.clear();
             errorMessageKeys.clear();

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/MultiSelectionField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/MultiSelectionField.java
@@ -9,9 +9,9 @@ package com.dlsc.formsfx.model.structure;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,10 +25,12 @@ import com.dlsc.formsfx.model.util.BindingMode;
 import com.dlsc.formsfx.model.validators.ValidationResult;
 import com.dlsc.formsfx.model.validators.Validator;
 import com.dlsc.formsfx.view.controls.SimpleListViewControl;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
+
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.ListProperty;
 import javafx.beans.property.SimpleListProperty;
@@ -60,10 +62,8 @@ public class MultiSelectionField<V> extends SelectionField<V, MultiSelectionFiel
     /**
      * The constructor of {@code MultiSelectionField}.
      *
-     * @param items
-     *              The property that is used to store the items of the field.
-     * @param selection
-     *              The list of indices of items that are to be selected.
+     * @param items     The property that is used to store the items of the field.
+     * @param selection The list of indices of items that are to be selected.
      */
     protected MultiSelectionField(ListProperty<V> items, List<Integer> selection) {
         super(items);
@@ -84,7 +84,7 @@ public class MultiSelectionField<V> extends SelectionField<V, MultiSelectionFiel
         // marked as changed until Field::persist or Field::reset are called
         // or the selection is back to the persistent selection.
 
-        changed.bind(Bindings.createBooleanBinding(() -> !persistentSelection.equals(this.selection), this.selection, persistentSelection));
+        changed.bind(Bindings.createBooleanBinding(() -> isVisible() && !persistentSelection.equals(this.selection), this.selection, persistentSelection, visibleProperty()));
 
         // Changes to the user input are reflected in the value only if the new
         // user input is valid.
@@ -107,11 +107,8 @@ public class MultiSelectionField<V> extends SelectionField<V, MultiSelectionFiel
      * Updates the list of available items to a new list, along with a
      * pre-defined selection.
      *
-     * @param newValue
-     *              The new list of items.
-     * @param newSelection
-     *              The new pre-defined selection.
-     *
+     * @param newValue     The new list of items.
+     * @param newSelection The new pre-defined selection.
      * @return Returns the current field to allow for chaining.
      */
     public MultiSelectionField<V> items(List<V> newValue, List<Integer> newSelection) {
@@ -127,9 +124,7 @@ public class MultiSelectionField<V> extends SelectionField<V, MultiSelectionFiel
      * Updates the list of available items to a new list, without a
      * pre-defined selection.
      *
-     * @param newValue
-     *              The new list of items.
-     *
+     * @param newValue The new list of items.
      * @return Returns the current field to allow for chaining.
      */
     public MultiSelectionField<V> items(List<V> newValue) {
@@ -140,10 +135,8 @@ public class MultiSelectionField<V> extends SelectionField<V, MultiSelectionFiel
      * Sets the list of validators for the current field. This overrides all
      * validators that have previously been added.
      *
-     * @param newValue
-     *              The validators that are to be used for validating this
-     *              field.
-     *
+     * @param newValue The validators that are to be used for validating this
+     *                 field.
      * @return Returns the current field to allow for chaining.
      */
     @SafeVarargs
@@ -158,9 +151,7 @@ public class MultiSelectionField<V> extends SelectionField<V, MultiSelectionFiel
     /**
      * Adds the element at the given index to the current selection.
      *
-     * @param index
-     *              The index of the element to be selected.
-     *
+     * @param index The index of the element to be selected.
      * @return Returns the current field to allow for chaining.
      */
     public MultiSelectionField<V> select(int index) {
@@ -174,9 +165,7 @@ public class MultiSelectionField<V> extends SelectionField<V, MultiSelectionFiel
     /**
      * Removes the element at the given index from the current selection.
      *
-     * @param index
-     *              The index of the element to be removed.
-     *
+     * @param index The index of the element to be removed.
      * @return Returns the current field to allow for chaining.
      */
     public MultiSelectionField<V> deselect(int index) {
@@ -191,12 +180,8 @@ public class MultiSelectionField<V> extends SelectionField<V, MultiSelectionFiel
      * Binds the given items and selection property with the corresponding
      * elements.
      *
-     * @param itemsBinding
-     *          The items property to be bound with.
-     *
-     * @param selectionBinding
-     *          The selection property to be bound with.
-     *
+     * @param itemsBinding     The items property to be bound with.
+     * @param selectionBinding The selection property to be bound with.
      * @return Returns the current field to allow for chaining.
      */
     public MultiSelectionField<V> bind(ListProperty<V> itemsBinding, ListProperty<V> selectionBinding) {
@@ -210,12 +195,8 @@ public class MultiSelectionField<V> extends SelectionField<V, MultiSelectionFiel
      * Unbinds the given items and selection property with the corresponding
      * elements.
      *
-     * @param itemsBinding
-     *          The items property to be unbound with.
-     *
-     * @param selectionBinding
-     *          The selection property to be unbound with.
-     *
+     * @param itemsBinding     The items property to be unbound with.
+     * @param selectionBinding The selection property to be unbound with.
      * @return Returns the current field to allow for chaining.
      */
     public MultiSelectionField<V> unbind(ListProperty<V> itemsBinding, ListProperty<V> selectionBinding) {
@@ -279,6 +260,13 @@ public class MultiSelectionField<V> extends SelectionField<V, MultiSelectionFiel
      * @return Returns whether the user selection is a valid value or not.
      */
     public boolean validate() {
+
+        if (!isVisible()) {
+            errorMessages.clear();
+            errorMessageKeys.clear();
+            valid.set(true);
+            return true;
+        }
 
         // Check all validation rules and collect any error messages.
 

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/SelectionField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/SelectionField.java
@@ -43,8 +43,8 @@ public abstract class SelectionField<V, F extends SelectionField<V, F>> extends 
      * Internal constructor for the {@code SelectionField} class. To create new
      * elements, see the static factory methods in {@code Field}.
      *
-     * @see Field::ofMultiSelectionType
-     * @see Field::ofSingleSelectionType
+     * @see Field#ofMultiSelectionType
+     * @see Field#ofSingleSelectionType
      *
      * @param items
      *              The list of available items on the field.

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/SelectionField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/SelectionField.java
@@ -9,9 +9,9 @@ package com.dlsc.formsfx.model.structure;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -43,14 +43,18 @@ public abstract class SelectionField<V, F extends SelectionField<V, F>> extends 
      * Internal constructor for the {@code SelectionField} class. To create new
      * elements, see the static factory methods in {@code Field}.
      *
+     * @param items The list of available items on the field.
      * @see Field#ofMultiSelectionType
      * @see Field#ofSingleSelectionType
-     *
-     * @param items
-     *              The list of available items on the field.
      */
     protected SelectionField(ListProperty<V> items) {
         this.items = items;
+        visible.addListener((ob, ov, nv) -> {
+            if (!nv) {
+                reset();
+            }
+            validate();
+        });
     }
 
     /**
@@ -64,16 +68,19 @@ public abstract class SelectionField<V, F extends SelectionField<V, F>> extends 
      * Validates a user input based on the field's selection and its validation
      * rules. Also considers the {@code required} flag. This method directly
      * updates the {@code valid} property.
-     *
+     * <p>
      * This method should not be called directly but instead only be used in
      * concrete subclasses.
      *
-     * @param errorMessages
-     *              A list of error messages based on the field's validators.
-     *
+     * @param errorMessages A list of error messages based on the field's validators.
      * @return Returns whether the user selection is a valid value or not.
      */
     protected boolean validate(List<String> errorMessages) {
+        if (!isVisible()) {
+            errorMessages.clear();
+            errorMessageKeys.clear();
+            return true;
+        }
         if (!validateRequired()) {
             if (isI18N() && requiredErrorKey.get() != null) {
                 this.errorMessageKeys.setAll(requiredErrorKey.get());
@@ -113,5 +120,4 @@ public abstract class SelectionField<V, F extends SelectionField<V, F>> extends 
     public ListProperty<V> itemsProperty() {
         return items;
     }
-
 }

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/SingleSelectionField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/SingleSelectionField.java
@@ -9,9 +9,9 @@ package com.dlsc.formsfx.model.structure;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,10 +25,12 @@ import com.dlsc.formsfx.model.util.BindingMode;
 import com.dlsc.formsfx.model.validators.ValidationResult;
 import com.dlsc.formsfx.model.validators.Validator;
 import com.dlsc.formsfx.view.controls.SimpleComboBoxControl;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
+
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.ListProperty;
 import javafx.beans.property.ObjectProperty;
@@ -59,10 +61,8 @@ public class SingleSelectionField<V> extends SelectionField<V, SingleSelectionFi
     /**
      * The constructor of {@code SingleSelectionField}.
      *
-     * @param items
-     *              The property that is used to store the items of the field.
-     * @param selection
-     *              The index of the item that is to be selected.
+     * @param items     The property that is used to store the items of the field.
+     * @param selection The index of the item that is to be selected.
      */
     protected SingleSelectionField(ListProperty<V> items, int selection) {
         super(items);
@@ -80,7 +80,10 @@ public class SingleSelectionField<V> extends SelectionField<V, SingleSelectionFi
         // marked as changed until Field::persist or Field::reset are called
         // or the selection is back to the persistent selection.
 
-        changed.bind(Bindings.createBooleanBinding(() -> isVisible() && persistentSelection.get() == null ? this.selection.get() != null : !persistentSelection.get().equals(this.selection.get()), this.selection, persistentSelection, visibleProperty()));
+        changed.bind(Bindings.createBooleanBinding(() -> {
+            if (!isVisible()) return false;
+            return persistentSelection.get() == null ? this.selection.get() != null : !persistentSelection.get().equals(this.selection.get());
+        }, this.selection, persistentSelection, visibleProperty()));
 
         // Changes to the user input are reflected in the value only if the new
         // user input is valid.
@@ -96,18 +99,15 @@ public class SingleSelectionField<V> extends SelectionField<V, SingleSelectionFi
             persistentSelection.setValue(null);
         });
 
-        rendererSupplier = () -> new SimpleComboBoxControl<>();
+        rendererSupplier = SimpleComboBoxControl::new;
     }
 
     /**
      * Updates the list of available items to a new list, along with a
      * pre-defined selection.
      *
-     * @param newValue
-     *              The new list of items.
-     * @param newSelection
-     *              The new pre-defined selection.
-     *
+     * @param newValue     The new list of items.
+     * @param newSelection The new pre-defined selection.
      * @return Returns the current field to allow for chaining.
      */
     public SingleSelectionField<V> items(List<V> newValue, int newSelection) {
@@ -125,9 +125,7 @@ public class SingleSelectionField<V> extends SelectionField<V, SingleSelectionFi
      * Updates the list of available items to a new list, without a
      * pre-defined selection.
      *
-     * @param newValue
-     *              The new list of items.
-     *
+     * @param newValue The new list of items.
      * @return Returns the current field to allow for chaining.
      */
     public SingleSelectionField<V> items(List<V> newValue) {
@@ -138,10 +136,8 @@ public class SingleSelectionField<V> extends SelectionField<V, SingleSelectionFi
      * Sets the list of validators for the current field. This overrides all
      * validators that have previously been added.
      *
-     * @param newValue
-     *              The validators that are to be used for validating this
-     *              field.
-     *
+     * @param newValue The validators that are to be used for validating this
+     *                 field.
      * @return Returns the current field to allow for chaining.
      */
     @SafeVarargs
@@ -156,9 +152,7 @@ public class SingleSelectionField<V> extends SelectionField<V, SingleSelectionFi
     /**
      * Sets the selection to the element at the given index.
      *
-     * @param index
-     *              The index of the element to be selected.
-     *
+     * @param index The index of the element to be selected.
      * @return Returns the current field to allow for chaining.
      */
     public SingleSelectionField<V> select(int index) {
@@ -188,12 +182,8 @@ public class SingleSelectionField<V> extends SelectionField<V, SingleSelectionFi
      * Binds the given items and selection property with the corresponding
      * elements.
      *
-     * @param itemsBinding
-     *          The items property to be bound with.
-     *
-     * @param selectionBinding
-     *          The selection property to be bound with.
-     *
+     * @param itemsBinding     The items property to be bound with.
+     * @param selectionBinding The selection property to be bound with.
      * @return Returns the current field to allow for chaining.
      */
     public SingleSelectionField<V> bind(ListProperty<V> itemsBinding, ObjectProperty<V> selectionBinding) {
@@ -207,12 +197,8 @@ public class SingleSelectionField<V> extends SelectionField<V, SingleSelectionFi
      * Unbinds the given items and selection property with the corresponding
      * elements.
      *
-     * @param itemsBinding
-     *          The items property to be unbound with.
-     *
-     * @param selectionBinding
-     *          The selection property to be unbound with.
-     *
+     * @param itemsBinding     The items property to be unbound with.
+     * @param selectionBinding The selection property to be unbound with.
      * @return Returns the current field to allow for chaining.
      */
     public SingleSelectionField<V> unbind(ListProperty<V> itemsBinding, ObjectProperty<V> selectionBinding) {

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/SingleSelectionField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/SingleSelectionField.java
@@ -80,7 +80,7 @@ public class SingleSelectionField<V> extends SelectionField<V, SingleSelectionFi
         // marked as changed until Field::persist or Field::reset are called
         // or the selection is back to the persistent selection.
 
-        changed.bind(Bindings.createBooleanBinding(() -> persistentSelection.get() == null ? this.selection.get() != null : !persistentSelection.get().equals(this.selection.get()), this.selection, persistentSelection));
+        changed.bind(Bindings.createBooleanBinding(() -> isVisible() && persistentSelection.get() == null ? this.selection.get() != null : !persistentSelection.get().equals(this.selection.get()), this.selection, persistentSelection, visibleProperty()));
 
         // Changes to the user input are reflected in the value only if the new
         // user input is valid.
@@ -276,6 +276,13 @@ public class SingleSelectionField<V> extends SelectionField<V, SingleSelectionFi
      * @return Returns whether the user selection is a valid value or not.
      */
     public boolean validate() {
+
+        if (!isVisible()) {
+            errorMessages.clear();
+            errorMessageKeys.clear();
+            valid.set(true);
+            return true;
+        }
 
         // Check all validation rules and collect any error messages.
 

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/SingleSelectionField.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/model/structure/SingleSelectionField.java
@@ -251,7 +251,7 @@ public class SingleSelectionField<V> extends SelectionField<V, SingleSelectionFi
      * {@inheritDoc}
      */
     protected boolean validateRequired() {
-        return !isRequired() || (isRequired() && selection.get() != null);
+        return !isVisible() || !isRequired() || (isRequired() && selection.get() != null);
     }
 
     /**
@@ -262,7 +262,6 @@ public class SingleSelectionField<V> extends SelectionField<V, SingleSelectionFi
      * @return Returns whether the user selection is a valid value or not.
      */
     public boolean validate() {
-
         if (!isVisible()) {
             errorMessages.clear();
             errorMessageKeys.clear();

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleBooleanControl.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleBooleanControl.java
@@ -9,9 +9,9 @@ package com.dlsc.formsfx.view.controls;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -39,7 +39,7 @@ public class SimpleBooleanControl extends SimpleControl<BooleanField> {
 
     /**
      * - fieldLabel is the container that displays the label property of the
-     *   field.
+     * field.
      * - checkBox is the editable checkbox to set user input.
      * - container holds the checkbox so that it can be styled properly.
      */
@@ -74,16 +74,31 @@ public class SimpleBooleanControl extends SimpleControl<BooleanField> {
 
         Node labelDescription = field.getLabelDescription();
         Node valueDescription = field.getValueDescription();
+        int fieldLabelColSpan = 2;
+        int controlRowIndex = 0;
+        int controlRowSpan = 1;
+        int controlColIndex = 2;
+        int controlColSpan = columns - fieldLabelColSpan;
+        if (field.isBlockLabel()) {
+            fieldLabelColSpan = columns;
+            controlColIndex = 0;
+            controlRowIndex = 1;
+            controlColSpan = columns;
+        }
 
-        add(fieldLabel, 0, 0, 2, 1);
+        add(fieldLabel, 0, 0, fieldLabelColSpan, 1);
+        GridPane.setValignment(fieldLabel, VPos.TOP);
         if (labelDescription != null) {
             GridPane.setValignment(labelDescription, VPos.TOP);
-            add(labelDescription, 0, 1, 2, 1);
+            add(labelDescription, 0, 1, fieldLabelColSpan, 1);
+            if (field.isBlockLabel())
+                controlRowIndex = 2;
         }
-        add(container, 2, 0, columns - 2, 1);
+        add(container, controlColIndex, controlRowIndex, controlColSpan, controlRowSpan);
+        GridPane.setValignment(container, VPos.TOP);
         if (valueDescription != null) {
             GridPane.setValignment(valueDescription, VPos.TOP);
-            add(valueDescription, 2, 1, columns - 2, 1);
+            add(valueDescription, controlColIndex, controlRowIndex + controlRowSpan, columns - 2, 1);
         }
     }
 

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleCheckBoxControl.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleCheckBoxControl.java
@@ -9,9 +9,9 @@ package com.dlsc.formsfx.view.controls;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -42,7 +42,7 @@ public class SimpleCheckBoxControl<V> extends SimpleControl<MultiSelectionField<
 
     /**
      * - The fieldLabel is the container that displays the label property of
-     *   the field.
+     * the field.
      * - The checkboxes list contains all the checkboxes to display.
      * - The box is a VBox holding all box.
      */
@@ -69,6 +69,7 @@ public class SimpleCheckBoxControl<V> extends SimpleControl<MultiSelectionField<
      * {@inheritDoc}
      */
     @Override
+    @SuppressWarnings("DuplicatedCode")
     public void layoutParts() {
         super.layoutParts();
 
@@ -78,16 +79,31 @@ public class SimpleCheckBoxControl<V> extends SimpleControl<MultiSelectionField<
 
         Node labelDescription = field.getLabelDescription();
         Node valueDescription = field.getValueDescription();
+        int fieldLabelColSpan = 2;
+        int controlRowIndex = 0;
+        int controlRowSpan = 1;
+        int controlColIndex = 2;
+        int controlColSpan = columns - fieldLabelColSpan;
+        if (field.isBlockLabel()) {
+            fieldLabelColSpan = columns;
+            controlColIndex = 0;
+            controlRowIndex = 1;
+            controlColSpan = columns;
+        }
 
-        add(fieldLabel, 0, 0, 2, 1);
+        add(fieldLabel, 0, 0, fieldLabelColSpan, 1);
+        GridPane.setValignment(fieldLabel, VPos.TOP);
         if (labelDescription != null) {
             GridPane.setValignment(labelDescription, VPos.TOP);
-            add(labelDescription, 0, 1, 2, 1);
+            add(labelDescription, 0, 1, fieldLabelColSpan, 1);
+            if (field.isBlockLabel())
+                controlRowIndex = 2;
         }
-        add(box, 2, 0, columns - 2, 1);
+        add(box, controlColIndex, controlRowIndex, controlColSpan, controlRowSpan);
+        GridPane.setValignment(box, VPos.TOP);
         if (valueDescription != null) {
             GridPane.setValignment(valueDescription, VPos.TOP);
-            add(valueDescription, 2, 1, columns - 2, 1);
+            add(valueDescription, controlColIndex, controlRowIndex + controlRowSpan, columns - 2, 1);
         }
     }
 

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleComboBoxControl.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleComboBoxControl.java
@@ -9,9 +9,9 @@ package com.dlsc.formsfx.view.controls;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -40,9 +40,9 @@ public class SimpleComboBoxControl<V> extends SimpleControl<SingleSelectionField
 
     /**
      * - The fieldLabel is the container that displays the label property of
-     *   the field.
+     * the field.
      * - The comboBox is the container that displays the values in the
-     *   ComboBox.
+     * ComboBox.
      * - The readOnlyLabel is used to show the current selection in read only.
      * - The stack is a StackPane to hold the field and read only label.
      */
@@ -73,6 +73,7 @@ public class SimpleComboBoxControl<V> extends SimpleControl<SingleSelectionField
      * {@inheritDoc}
      */
     @Override
+    @SuppressWarnings("DuplicatedCode")
     public void layoutParts() {
         super.layoutParts();
 
@@ -87,17 +88,43 @@ public class SimpleComboBoxControl<V> extends SimpleControl<SingleSelectionField
 
         Node labelDescription = field.getLabelDescription();
         Node valueDescription = field.getValueDescription();
+        int fieldLabelColSpan = 2;
+        int controlRowIndex = 0;
+        int controlRowSpan = 1;
+        int controlColIndex = 2;
+        int controlColSpan = columns - fieldLabelColSpan;
+        if (field.isBlockLabel()) {
+            fieldLabelColSpan = columns;
+            controlColIndex = 0;
+            controlRowIndex = 1;
+            controlColSpan = columns;
+        }
 
-        add(fieldLabel, 0, 0, 2, 1);
+        add(fieldLabel, 0, 0, fieldLabelColSpan, 1);
+        GridPane.setValignment(fieldLabel, VPos.TOP);
         if (labelDescription != null) {
             GridPane.setValignment(labelDescription, VPos.TOP);
-            add(labelDescription, 0, 1, 2, 1);
+            add(labelDescription, 0, 1, fieldLabelColSpan, 1);
+            if (field.isBlockLabel())
+                controlRowIndex = 2;
         }
-        add(stack, 2, 0, columns - 2, 1);
+        add(stack, controlColIndex, controlRowIndex, controlColSpan, controlRowSpan);
+        GridPane.setValignment(stack, VPos.TOP);
         if (valueDescription != null) {
             GridPane.setValignment(valueDescription, VPos.TOP);
-            add(valueDescription, 2, 1, columns - 2, 1);
+            add(valueDescription, controlColIndex, controlRowIndex + controlRowSpan, columns - 2, 1);
         }
+//
+//        add(fieldLabel, 0, 0, 2, 1);
+//        if (labelDescription != null) {
+//            GridPane.setValignment(labelDescription, VPos.TOP);
+//            add(labelDescription, 0, 1, 2, 1);
+//        }
+//        add(stack, 2, 0, columns - 2, 1);
+//        if (valueDescription != null) {
+//            GridPane.setValignment(valueDescription, VPos.TOP);
+//            add(valueDescription, 2, 1, columns - 2, 1);
+//        }
     }
 
     /**

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleControl.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleControl.java
@@ -60,7 +60,8 @@ public abstract class SimpleControl<F extends Field> extends GridPane implements
 
     public void setField(F field) {
         if (this.field != null) {
-            throw new IllegalStateException("Cannot change a control's field once set.");
+            return;
+//            throw new IllegalStateException("Cannot change a control's field once set.");
         }
 
         this.field = field;

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleDateControl.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleDateControl.java
@@ -67,17 +67,43 @@ public class SimpleDateControl extends SimpleControl<DateField> {
 
         Node labelDescription = field.getLabelDescription();
         Node valueDescription = field.getValueDescription();
+        int fieldLabelColSpan = 2;
+        int controlRowIndex = 0;
+        int controlRowSpan = 1;
+        int controlColIndex = 2;
+        int controlColSpan = columns - fieldLabelColSpan;
+        if (field.isBlockLabel()) {
+            fieldLabelColSpan = columns;
+            controlColIndex = 0;
+            controlRowIndex = 1;
+            controlColSpan = columns;
+        }
 
-        add(fieldLabel, 0, 0, 2, 1);
+        add(fieldLabel, 0, 0, fieldLabelColSpan, 1);
+        GridPane.setValignment(fieldLabel, VPos.TOP);
         if (labelDescription != null) {
             GridPane.setValignment(labelDescription, VPos.TOP);
-            add(labelDescription, 0, 1, 2, 1);
+            add(labelDescription, 0, 1, fieldLabelColSpan, 1);
+            if (field.isBlockLabel())
+                controlRowIndex = 2;
         }
-        add(stack, 2, 0, columns - 2, 1);
+        add(picker, controlColIndex, controlRowIndex, controlColSpan, controlRowSpan);
+        GridPane.setValignment(picker, VPos.TOP);
         if (valueDescription != null) {
             GridPane.setValignment(valueDescription, VPos.TOP);
-            add(valueDescription, 2, 1, columns - 2, 1);
+            add(valueDescription, controlColIndex, controlRowIndex + controlRowSpan, columns - 2, 1);
         }
+//
+//        add(fieldLabel, 0, 0, 2, 1);
+//        if (labelDescription != null) {
+//            GridPane.setValignment(labelDescription, VPos.TOP);
+//            add(labelDescription, 0, 1, 2, 1);
+//        }
+//        add(stack, 2, 0, columns - 2, 1);
+//        if (valueDescription != null) {
+//            GridPane.setValignment(valueDescription, VPos.TOP);
+//            add(valueDescription, 2, 1, columns - 2, 1);
+//        }
     }
 
     @Override

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleListViewControl.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleListViewControl.java
@@ -9,9 +9,9 @@ package com.dlsc.formsfx.view.controls;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -40,7 +40,7 @@ public class SimpleListViewControl<V> extends SimpleControl<MultiSelectionField<
 
     /**
      * - The fieldLabel is the container that displays the label property of
-     *   the field.
+     * the field.
      * - The listView is the container that displays list values.
      */
     protected Label fieldLabel;
@@ -88,16 +88,43 @@ public class SimpleListViewControl<V> extends SimpleControl<MultiSelectionField<
         Node labelDescription = field.getLabelDescription();
         Node valueDescription = field.getValueDescription();
 
-        add(fieldLabel, 0, 0, 2, 1);
+        int fieldLabelColSpan = 2;
+        int controlRowIndex = 0;
+        int controlRowSpan = 1;
+        int controlColIndex = 2;
+        int controlColSpan = columns - fieldLabelColSpan;
+        if (field.isBlockLabel()) {
+            fieldLabelColSpan = columns;
+            controlColIndex = 0;
+            controlRowIndex = 1;
+            controlColSpan = columns;
+        }
+
+        add(fieldLabel, 0, 0, fieldLabelColSpan, 1);
+        GridPane.setValignment(fieldLabel, VPos.TOP);
         if (labelDescription != null) {
             GridPane.setValignment(labelDescription, VPos.TOP);
-            add(labelDescription, 0, 1, 2, 1);
+            add(labelDescription, 0, 1, fieldLabelColSpan, 1);
+            if (field.isBlockLabel())
+                controlRowIndex = 2;
         }
-        add(listView, 2, 0, columns - 2, 1);
+        add(listView, controlColIndex, controlRowIndex, controlColSpan, controlRowSpan);
+        GridPane.setValignment(listView, VPos.TOP);
         if (valueDescription != null) {
             GridPane.setValignment(valueDescription, VPos.TOP);
-            add(valueDescription, 2, 1, columns - 2, 1);
+            add(valueDescription, controlColIndex, controlRowIndex + controlRowSpan, columns - 2, 1);
         }
+
+//        add(fieldLabel, 0, 0, 2, 1);
+//        if (labelDescription != null) {
+//            GridPane.setValignment(labelDescription, VPos.TOP);
+//            add(labelDescription, 0, 1, 2, 1);
+//        }
+//        add(listView, 2, 0, columns - 2, 1);
+//        if (valueDescription != null) {
+//            GridPane.setValignment(valueDescription, VPos.TOP);
+//            add(valueDescription, 2, 1, columns - 2, 1);
+//        }
     }
 
     /**

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleNumberControl.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleNumberControl.java
@@ -87,31 +87,57 @@ public abstract class SimpleNumberControl<F extends DataField, D extends Number>
         Node valueDescription = field.getValueDescription();
 
         int columns = field.getSpan();
-
-        if (columns < 3) {
-            int rowIndex = 0;
-            add(fieldLabel, 0, rowIndex++, columns, 1);
-            if (labelDescription != null) {
-                GridPane.setValignment(labelDescription, VPos.TOP);
-                add(labelDescription, 0, rowIndex++, columns, 1);
-            }
-            add(stack, 0, rowIndex++, columns, 1);
-            if (valueDescription != null) {
-                GridPane.setValignment(valueDescription, VPos.TOP);
-                add(valueDescription, 0, rowIndex, columns, 1);
-            }
-        } else {
-            add(fieldLabel, 0, 0, 2, 1);
-            if (labelDescription != null) {
-                GridPane.setValignment(labelDescription, VPos.TOP);
-                add(labelDescription, 0, 1, 2, 1);
-            }
-            add(stack, 2, 0, columns - 2, 1);
-            if (valueDescription != null) {
-                GridPane.setValignment(valueDescription, VPos.TOP);
-                add(valueDescription, 2, 1, columns - 2, 1);
-            }
+        int fieldLabelColSpan = 2;
+        int controlRowIndex = 0;
+        int controlRowSpan = 1;
+        int controlColIndex = 2;
+        int controlColSpan = columns - fieldLabelColSpan;
+        if (field.isBlockLabel()) {
+            fieldLabelColSpan = columns;
+            controlColIndex = 0;
+            controlRowIndex = 1;
+            controlColSpan = columns;
         }
+
+        add(fieldLabel, 0, 0, fieldLabelColSpan, 1);
+        GridPane.setValignment(fieldLabel, VPos.TOP);
+        if (labelDescription != null) {
+            GridPane.setValignment(labelDescription, VPos.TOP);
+            add(labelDescription, 0, 1, fieldLabelColSpan, 1);
+            if (field.isBlockLabel())
+                controlRowIndex = 2;
+        }
+        add(stack, controlColIndex, controlRowIndex, controlColSpan, controlRowSpan);
+        GridPane.setValignment(stack, VPos.TOP);
+        if (valueDescription != null) {
+            GridPane.setValignment(valueDescription, VPos.TOP);
+            add(valueDescription, controlColIndex, controlRowIndex + controlRowSpan, columns - 2, 1);
+        }
+
+//        if (columns < 3) {
+//            int rowIndex = 0;
+//            add(fieldLabel, 0, rowIndex++, columns, 1);
+//            if (labelDescription != null) {
+//                GridPane.setValignment(labelDescription, VPos.TOP);
+//                add(labelDescription, 0, rowIndex++, columns, 1);
+//            }
+//            add(stack, 0, rowIndex++, columns, 1);
+//            if (valueDescription != null) {
+//                GridPane.setValignment(valueDescription, VPos.TOP);
+//                add(valueDescription, 0, rowIndex, columns, 1);
+//            }
+//        } else {
+//            add(fieldLabel, 0, 0, 2, 1);
+//            if (labelDescription != null) {
+//                GridPane.setValignment(labelDescription, VPos.TOP);
+//                add(labelDescription, 0, 1, 2, 1);
+//            }
+//            add(stack, 2, 0, columns - 2, 1);
+//            if (valueDescription != null) {
+//                GridPane.setValignment(valueDescription, VPos.TOP);
+//                add(valueDescription, 2, 1, columns - 2, 1);
+//            }
+//        }
     }
 
     /**

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimplePasswordControl.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimplePasswordControl.java
@@ -100,31 +100,57 @@ public class SimplePasswordControl extends SimpleControl<PasswordField> {
         Node valueDescription = field.getValueDescription();
 
         int columns = field.getSpan();
-
-        if (columns < 3) {
-            int rowIndex = 0;
-            add(fieldLabel, 0, rowIndex++, columns, 1);
-            if (labelDescription != null) {
-                GridPane.setValignment(labelDescription, VPos.TOP);
-                add(labelDescription, 0, rowIndex++, columns, 1);
-            }
-            add(stack, 0, rowIndex++, columns, 1);
-            if (valueDescription != null) {
-                GridPane.setValignment(valueDescription, VPos.TOP);
-                add(valueDescription, 0, rowIndex, columns, 1);
-            }
-        } else {
-            add(fieldLabel, 0, 0, 2, 1);
-            if (labelDescription != null) {
-                GridPane.setValignment(labelDescription, VPos.TOP);
-                add(labelDescription, 0, 1, 2, 1);
-            }
-            add(stack, 2, 0, columns - 2, 1);
-            if (valueDescription != null) {
-                GridPane.setValignment(valueDescription, VPos.TOP);
-                add(valueDescription, 2, 1, columns - 2, 1);
-            }
+        int fieldLabelColSpan = 2;
+        int controlRowIndex = 0;
+        int controlRowSpan = 1;
+        int controlColIndex = 2;
+        int controlColSpan = columns - fieldLabelColSpan;
+        if (field.isBlockLabel()) {
+            fieldLabelColSpan = columns;
+            controlColIndex = 0;
+            controlRowIndex = 1;
+            controlColSpan = columns;
         }
+
+        add(fieldLabel, 0, 0, fieldLabelColSpan, 1);
+        GridPane.setValignment(fieldLabel, VPos.TOP);
+        if (labelDescription != null) {
+            GridPane.setValignment(labelDescription, VPos.TOP);
+            add(labelDescription, 0, 1, fieldLabelColSpan, 1);
+            if (field.isBlockLabel())
+                controlRowIndex = 2;
+        }
+        add(stack, controlColIndex, controlRowIndex, controlColSpan, controlRowSpan);
+        GridPane.setValignment(stack, VPos.TOP);
+        if (valueDescription != null) {
+            GridPane.setValignment(valueDescription, VPos.TOP);
+            add(valueDescription, controlColIndex, controlRowIndex + controlRowSpan, columns - 2, 1);
+        }
+
+//        if (columns < 3) {
+//            int rowIndex = 0;
+//            add(fieldLabel, 0, rowIndex++, columns, 1);
+//            if (labelDescription != null) {
+//                GridPane.setValignment(labelDescription, VPos.TOP);
+//                add(labelDescription, 0, rowIndex++, columns, 1);
+//            }
+//            add(stack, 0, rowIndex++, columns, 1);
+//            if (valueDescription != null) {
+//                GridPane.setValignment(valueDescription, VPos.TOP);
+//                add(valueDescription, 0, rowIndex, columns, 1);
+//            }
+//        } else {
+//            add(fieldLabel, 0, 0, 2, 1);
+//            if (labelDescription != null) {
+//                GridPane.setValignment(labelDescription, VPos.TOP);
+//                add(labelDescription, 0, 1, 2, 1);
+//            }
+//            add(stack, 2, 0, columns - 2, 1);
+//            if (valueDescription != null) {
+//                GridPane.setValignment(valueDescription, VPos.TOP);
+//                add(valueDescription, 2, 1, columns - 2, 1);
+//            }
+//        }
     }
 
     /**

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleRadioButtonControl.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleRadioButtonControl.java
@@ -65,6 +65,7 @@ public class SimpleRadioButtonControl<V> extends SimpleControl<SingleSelectionFi
         fieldLabel = new Label(field.labelProperty().getValue());
         toggleGroup = new ToggleGroup();
         box = new VBox();
+        field.blockedLabel(false);
 
         createRadioButtons();
     }
@@ -83,16 +84,43 @@ public class SimpleRadioButtonControl<V> extends SimpleControl<SingleSelectionFi
         Node labelDescription = field.getLabelDescription();
         Node valueDescription = field.getValueDescription();
 
-        add(fieldLabel, 0, 0, 2, 1);
+        int fieldLabelColSpan = 2;
+        int controlRowIndex = 0;
+        int controlRowSpan = 1;
+        int controlColIndex = 2;
+        int controlColSpan = columns - fieldLabelColSpan;
+        if (field.isBlockLabel()) {
+            fieldLabelColSpan = columns;
+            controlColIndex = 0;
+            controlRowIndex = 1;
+            controlColSpan = columns;
+        }
+
+        add(fieldLabel, 0, 0, fieldLabelColSpan, 1);
+        GridPane.setValignment(fieldLabel, VPos.TOP);
         if (labelDescription != null) {
             GridPane.setValignment(labelDescription, VPos.TOP);
-            add(labelDescription, 0, 1, 2, 1);
+            add(labelDescription, 0, 1, fieldLabelColSpan, 1);
+            if (field.isBlockLabel())
+                controlRowIndex = 2;
         }
-        add(box, 2, 0, columns - 2, 1);
+        add(box, controlColIndex, controlRowIndex, controlColSpan, controlRowSpan);
+        GridPane.setValignment(box, VPos.TOP);
         if (valueDescription != null) {
             GridPane.setValignment(valueDescription, VPos.TOP);
-            add(valueDescription, 2, 1, columns - 2, 1);
+            add(valueDescription, controlColIndex, controlRowIndex + controlRowSpan, columns - 2, 1);
         }
+
+//        add(fieldLabel, 0, 0, 2, 1);
+//        if (labelDescription != null) {
+//            GridPane.setValignment(labelDescription, VPos.TOP);
+//            add(labelDescription, 0, 1, 2, 1);
+//        }
+//        add(box, 2, 0, columns - 2, 1);
+//        if (valueDescription != null) {
+//            GridPane.setValignment(valueDescription, VPos.TOP);
+//            add(valueDescription, 2, 1, columns - 2, 1);
+//        }
     }
 
     /**

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleTextControl.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/view/controls/SimpleTextControl.java
@@ -106,31 +106,57 @@ public class SimpleTextControl extends SimpleControl<StringField> {
         Node valueDescription = field.getValueDescription();
 
         int columns = field.getSpan();
-
-        if (columns < 3) {
-            int rowIndex = 0;
-            add(fieldLabel, 0, rowIndex++, columns, 1);
-            if (labelDescription != null) {
-                GridPane.setValignment(labelDescription, VPos.TOP);
-                add(labelDescription, 0, rowIndex++, columns, 1);
-            }
-            add(stack, 0, rowIndex++, columns, 1);
-            if (valueDescription != null) {
-                GridPane.setValignment(valueDescription, VPos.TOP);
-                add(valueDescription, 0, rowIndex, columns, 1);
-            }
-        } else {
-            add(fieldLabel, 0, 0, 2, 1);
-            if (labelDescription != null) {
-                GridPane.setValignment(labelDescription, VPos.TOP);
-                add(labelDescription, 0, 1, 2, 1);
-            }
-            add(stack, 2, 0, columns - 2, 1);
-            if (valueDescription != null) {
-                GridPane.setValignment(valueDescription, VPos.TOP);
-                add(valueDescription, 2, 1, columns - 2, 1);
-            }
+        int fieldLabelColSpan = 2;
+        int controlRowIndex = 0;
+        int controlRowSpan = 1;
+        int controlColIndex = 2;
+        int controlColSpan = columns - fieldLabelColSpan;
+        if (field.isBlockLabel()) {
+            fieldLabelColSpan = columns;
+            controlColIndex = 0;
+            controlRowIndex = 1;
+            controlColSpan = columns;
         }
+
+        add(fieldLabel, 0, 0, fieldLabelColSpan, 1);
+        GridPane.setValignment(fieldLabel, VPos.TOP);
+        if (labelDescription != null) {
+            GridPane.setValignment(labelDescription, VPos.TOP);
+            add(labelDescription, 0, 1, fieldLabelColSpan, 1);
+            if (field.isBlockLabel())
+                controlRowIndex = 2;
+        }
+        add(stack, controlColIndex, controlRowIndex, controlColSpan, controlRowSpan);
+        GridPane.setValignment(stack, VPos.TOP);
+        if (valueDescription != null) {
+            GridPane.setValignment(valueDescription, VPos.TOP);
+            add(valueDescription, controlColIndex, controlRowIndex + controlRowSpan, columns - 2, 1);
+        }
+
+//        if (columns < 3) {
+//            int rowIndex = 0;
+//            add(fieldLabel, 0, rowIndex++, columns, 1);
+//            if (labelDescription != null) {
+//                GridPane.setValignment(labelDescription, VPos.TOP);
+//                add(labelDescription, 0, rowIndex++, columns, 1);
+//            }
+//            add(stack, 0, rowIndex++, columns, 1);
+//            if (valueDescription != null) {
+//                GridPane.setValignment(valueDescription, VPos.TOP);
+//                add(valueDescription, 0, rowIndex, columns, 1);
+//            }
+//        } else {
+//            add(fieldLabel, 0, 0, 2, 1);
+//            if (labelDescription != null) {
+//                GridPane.setValignment(labelDescription, VPos.TOP);
+//                add(labelDescription, 0, 1, 2, 1);
+//            }
+//            add(stack, 2, 0, columns - 2, 1);
+//            if (valueDescription != null) {
+//                GridPane.setValignment(valueDescription, VPos.TOP);
+//                add(valueDescription, 2, 1, columns - 2, 1);
+//            }
+//        }
     }
 
     /**

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/view/renderer/GroupRendererBase.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/view/renderer/GroupRendererBase.java
@@ -111,10 +111,8 @@ public abstract class GroupRendererBase<V extends Group> extends StackPane imple
     @Override
     public void setupValueChangedListeners() {
         ViewMixin.super.setupValueChangedListeners();
-        element.getElements().stream()
-                .filter(e -> e instanceof Field)
-                .map(Field.class::cast)
-                .forEach(f -> f.visibleProperty().addListener(ob -> {
+        element.getElements()
+                .forEach(f -> f.visibleProperty().addListener((ob, ov, nv) -> {
                     grid.getChildren().clear();
                     renderElements();
                 }));

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/view/renderer/GroupRendererBase.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/view/renderer/GroupRendererBase.java
@@ -72,7 +72,7 @@ public abstract class GroupRendererBase<V extends Group> extends StackPane imple
         renderElements();
     }
 
-    private void renderElements() {
+    protected void renderElements() {
         int COLUMN_COUNT = 12;
 
         grid.setHgap(SPACING);

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/view/renderer/GroupRendererBase.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/view/renderer/GroupRendererBase.java
@@ -9,9 +9,9 @@ package com.dlsc.formsfx.view.renderer;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -41,7 +41,7 @@ public abstract class GroupRendererBase<V extends Group> extends StackPane imple
 
     /**
      * - SPACING is used to set the spacing of the section as well as the
-     *   spacing for vertical/horizontal gaps between controls.
+     * spacing for vertical/horizontal gaps between controls.
      */
     protected final int SPACING = 10;
 
@@ -81,6 +81,7 @@ public abstract class GroupRendererBase<V extends Group> extends StackPane imple
         // takes up too much horizontal space, wrap it to the next row.
 
         for (Element e : element.getElements()) {
+            if (!e.isVisible()) continue;
             int span = e.getSpan();
 
             if (currentColumnCount + span > COLUMN_COUNT) {
@@ -94,11 +95,20 @@ public abstract class GroupRendererBase<V extends Group> extends StackPane imple
                 c.setField(f);
 
                 grid.add(c, currentColumnCount, currentRow, span, 1);
-            } else if (e instanceof NodeElement){
-                grid.add(((NodeElement)e).getNode(), currentColumnCount, currentRow, span, 1);
+            } else if (e instanceof NodeElement) {
+                grid.add(((NodeElement) e).getNode(), currentColumnCount, currentRow, span, 1);
             }
 
             currentColumnCount += span;
         }
+    }
+
+    @Override
+    public void setupValueChangedListeners() {
+        ViewMixin.super.setupValueChangedListeners();
+        element.getElements().stream()
+                .filter(e -> e instanceof Field)
+                .map(Field.class::cast)
+                .forEach(f -> f.visibleProperty().addListener(ob -> layoutParts()));
     }
 }

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/view/renderer/GroupRendererBase.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/view/renderer/GroupRendererBase.java
@@ -69,6 +69,11 @@ public abstract class GroupRendererBase<V extends Group> extends StackPane imple
             colConst.setPercentWidth(100.0 / COLUMN_COUNT);
             grid.getColumnConstraints().add(colConst);
         }
+        renderElements();
+    }
+
+    private void renderElements() {
+        int COLUMN_COUNT = 12;
 
         grid.setHgap(SPACING);
         grid.setVgap(SPACING);
@@ -109,6 +114,9 @@ public abstract class GroupRendererBase<V extends Group> extends StackPane imple
         element.getElements().stream()
                 .filter(e -> e instanceof Field)
                 .map(Field.class::cast)
-                .forEach(f -> f.visibleProperty().addListener(ob -> layoutParts()));
+                .forEach(f -> f.visibleProperty().addListener(ob -> {
+                    grid.getChildren().clear();
+                    renderElements();
+                }));
     }
 }

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/view/renderer/SectionRenderer.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/view/renderer/SectionRenderer.java
@@ -77,6 +77,11 @@ public class SectionRenderer extends GroupRendererBase<Section> {
         titledPane.collapsibleProperty().bind(element.collapsibleProperty());
         titledPane.expandedProperty().addListener((observable, oldValue, newValue) -> element.collapsedProperty().setValue(!newValue));
         element.collapsedProperty().addListener((observable, oldValue, newValue) -> titledPane.expandedProperty().setValue(!newValue));
+        element.getElements()
+                .forEach(f -> f.visibleProperty().addListener((ob, ov, nv) -> {
+                    grid.getChildren().clear();
+                    renderElements();
+                }));
     }
 
     /**

--- a/formsfx-core/src/main/java/com/dlsc/formsfx/view/util/ColSpan.java
+++ b/formsfx-core/src/main/java/com/dlsc/formsfx/view/util/ColSpan.java
@@ -27,7 +27,6 @@ package com.dlsc.formsfx.view.util;
  * @author Rinesch Murugathas
  */
 public enum ColSpan {
-
     FIVE_SIXTH(10),
     TWO_THIRD(8),
     HALF(6),

--- a/formsfx-core/src/test/java/com/dlsc/formsfx/model/structure/FieldTest.java
+++ b/formsfx-core/src/test/java/com/dlsc/formsfx/model/structure/FieldTest.java
@@ -23,18 +23,7 @@ package com.dlsc.formsfx.model.structure;
 import com.dlsc.formsfx.model.validators.StringLengthValidator;
 import com.dlsc.formsfx.view.util.ColSpan;
 import javafx.application.Platform;
-import javafx.beans.property.BooleanProperty;
-import javafx.beans.property.DoubleProperty;
-import javafx.beans.property.IntegerProperty;
-import javafx.beans.property.ListProperty;
-import javafx.beans.property.ObjectProperty;
-import javafx.beans.property.SimpleBooleanProperty;
-import javafx.beans.property.SimpleDoubleProperty;
-import javafx.beans.property.SimpleIntegerProperty;
-import javafx.beans.property.SimpleListProperty;
-import javafx.beans.property.SimpleObjectProperty;
-import javafx.beans.property.SimpleStringProperty;
-import javafx.beans.property.StringProperty;
+import javafx.beans.property.*;
 import javafx.collections.FXCollections;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -42,7 +31,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * @author Sacha Schmid
@@ -68,22 +56,6 @@ public class FieldTest {
                 .validate(StringLengthValidator.atLeast(1, "invalid"));
         Assert.assertTrue(s.isVisible());
         Assert.assertFalse(s.isValid());
-    }
-
-    @Test
-    public void fieldValidWhileInvisibleTest() {
-        String invisibleDefault = "invisible";
-        StringProperty valueProperty = new SimpleStringProperty("something");
-        BooleanProperty visibilityBinding = new SimpleBooleanProperty(false);
-        StringField s = Field.ofStringType(valueProperty)
-                .visibility(visibilityBinding, invisibleDefault);
-        s.required("This field is required").validate(StringLengthValidator.atLeast(1, "test"));
-        Assert.assertFalse(s.isVisible());
-        Assert.assertTrue(s.isValid());
-
-        valueProperty.setValue("something 2");
-        Assert.assertEquals(invisibleDefault, s.getValue());
-        Assert.assertFalse(s.hasChanged());
     }
 
     @Test

--- a/formsfx-core/src/test/java/com/dlsc/formsfx/model/structure/FieldTest.java
+++ b/formsfx-core/src/test/java/com/dlsc/formsfx/model/structure/FieldTest.java
@@ -42,6 +42,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * @author Sacha Schmid
@@ -53,10 +54,36 @@ public class FieldTest {
     @BeforeClass
     public static void beforeClass() {
         try {
-            Platform.startup(() -> {});
+            Platform.startup(() -> {
+            });
         } catch (IllegalStateException ex) {
             // JavaFX may only be initialized once.
         }
+    }
+
+    @Test
+    public void fieldInvalidWhileVisibleTest() {
+        StringField s = Field.ofStringType("")
+                .required("This field is required")
+                .validate(StringLengthValidator.atLeast(1, "invalid"));
+        Assert.assertTrue(s.isVisible());
+        Assert.assertFalse(s.isValid());
+    }
+
+    @Test
+    public void fieldValidWhileInvisibleTest() {
+        String invisibleDefault = "invisible";
+        StringProperty valueProperty = new SimpleStringProperty("something");
+        BooleanProperty visibilityBinding = new SimpleBooleanProperty(false);
+        StringField s = Field.ofStringType(valueProperty)
+                .visibility(visibilityBinding, invisibleDefault);
+        s.required("This field is required").validate(StringLengthValidator.atLeast(1, "test"));
+        Assert.assertFalse(s.isVisible());
+        Assert.assertTrue(s.isValid());
+
+        valueProperty.setValue("something 2");
+        Assert.assertEquals(invisibleDefault, s.getValue());
+        Assert.assertFalse(s.hasChanged());
     }
 
     @Test

--- a/formsfx-demo/src/main/java/com/dlsc/formsfx/demo/model/Country.java
+++ b/formsfx-demo/src/main/java/com/dlsc/formsfx/demo/model/Country.java
@@ -15,32 +15,31 @@ import java.time.Month;
  */
 public class Country {
 
-    private StringProperty name = new SimpleStringProperty("Switzerland");
-    private StringProperty iso = new SimpleStringProperty("CH");
-    private BooleanProperty independence = new SimpleBooleanProperty(true);
-    private ObjectProperty<LocalDate> independenceDay = new SimpleObjectProperty<>(LocalDate.of(1648, Month.OCTOBER, 24));
+    private final StringProperty name = new SimpleStringProperty("Switzerland");
+    private final StringProperty iso = new SimpleStringProperty("CH");
+    private final BooleanProperty independence = new SimpleBooleanProperty(true);
+    private final ObjectProperty<LocalDate> independenceDay = new SimpleObjectProperty<>(LocalDate.of(1648, Month.OCTOBER, 24));
 
-    private StringProperty currencyShort = new SimpleStringProperty("CHF");
-    private StringProperty currencyLong = new SimpleStringProperty("Swiss Franc");
+    private final StringProperty currencyShort = new SimpleStringProperty("CHF");
+    private final StringProperty currencyLong = new SimpleStringProperty("Swiss Franc");
 
-    private IntegerProperty population = new SimpleIntegerProperty(8401120);
-    private DoubleProperty area = new SimpleDoubleProperty(41285);
-    private StringProperty tld = new SimpleStringProperty(".ch");
+    private final IntegerProperty population = new SimpleIntegerProperty(8401120);
+    private final DoubleProperty area = new SimpleDoubleProperty(41285);
+    private final StringProperty tld = new SimpleStringProperty(".ch");
 
-    private StringProperty dateFormat = new SimpleStringProperty("dd.mm.yyyy");
-    private ObjectProperty<String> driverSide = new SimpleObjectProperty<>("Right");
-    private StringProperty timeZone = new SimpleStringProperty("CET");
-    private StringProperty summerTimeZone = new SimpleStringProperty("CEST");
+    private final StringProperty dateFormat = new SimpleStringProperty("dd.mm.yyyy");
+    private final ObjectProperty<String> driverSide = new SimpleObjectProperty<>("Right");
+    private final StringProperty timeZone = new SimpleStringProperty("CET");
+    private final StringProperty summerTimeZone = new SimpleStringProperty("CEST");
 
-    private ListProperty<String> allSides = new SimpleListProperty<>(FXCollections.observableArrayList("Right", "Left"));
-    private ListProperty<String> allCities = new SimpleListProperty<>(FXCollections.observableArrayList("Zurich (ZH)", "Geneva (GE)", "Basel (BS)", "Lausanne (VD)", "Bern (BE)", "Winterthur (ZH)", "Lucerne (LU)", "St. Gallen (SG)", "Lugano (TI)", "Biel (BE)"));
-    private ListProperty<String> allCapitals = new SimpleListProperty<>(FXCollections.observableArrayList("Zurich (ZH)", "Geneva (GE)", "Basel (BS)", "Lausanne (VD)", "Bern (BE)", "Winterthur (ZH)", "Lucerne (LU)", "St. Gallen (SG)", "Lugano (TI)", "Biel (BE)"));
-    private ListProperty<String> allContinents = new SimpleListProperty<>(FXCollections.observableArrayList("Africa", "Asia", "Europe", "North America", "South America", "Australia"));
+    private final ListProperty<String> allSides = new SimpleListProperty<>(FXCollections.observableArrayList("Right", "Left"));
+    private final ListProperty<String> allCities = new SimpleListProperty<>(FXCollections.observableArrayList("Zurich (ZH)", "Geneva (GE)", "Basel (BS)", "Lausanne (VD)", "Bern (BE)", "Winterthur (ZH)", "Lucerne (LU)", "St. Gallen (SG)", "Lugano (TI)", "Biel (BE)"));
+    private final ListProperty<String> allCapitals = new SimpleListProperty<>(FXCollections.observableArrayList("Zurich (ZH)", "Geneva (GE)", "Basel (BS)", "Lausanne (VD)", "Bern (BE)", "Winterthur (ZH)", "Lucerne (LU)", "St. Gallen (SG)", "Lugano (TI)", "Biel (BE)"));
+    private final ListProperty<String> allContinents = new SimpleListProperty<>(FXCollections.observableArrayList("Africa", "Asia", "Europe", "North America", "South America", "Australia"));
+    private final ListProperty<String> continents = new SimpleListProperty<>(FXCollections.observableArrayList("Europe"));
 
-    private ListProperty<String> continents = new SimpleListProperty<>(FXCollections.observableArrayList("Europe"));
-
-    private ObjectProperty<String> capital = new SimpleObjectProperty<>("Bern (BE)");
-    private ListProperty<String> germanCities = new SimpleListProperty<>(FXCollections.observableArrayList("Zurich (ZH)", "Basel (BS)", "Bern (BE)", "Winterthur (ZH)", "Lucerne (LU)", "St. Gallen (SG)", "Biel (BE)"));
+    private final ObjectProperty<String> capital = new SimpleObjectProperty<>("Bern (BE)");
+    private final ListProperty<String> germanCities = new SimpleListProperty<>(FXCollections.observableArrayList());
 
     public String getName() {
         return name.get();

--- a/formsfx-demo/src/main/java/com/dlsc/formsfx/demo/model/DemoModel.java
+++ b/formsfx-demo/src/main/java/com/dlsc/formsfx/demo/model/DemoModel.java
@@ -12,6 +12,8 @@ import com.dlsc.formsfx.model.validators.StringLengthValidator;
 import com.dlsc.formsfx.view.controls.SimpleCheckBoxControl;
 import com.dlsc.formsfx.view.controls.SimpleRadioButtonControl;
 import com.dlsc.formsfx.view.util.ColSpan;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
 
 import java.util.Locale;
 import java.util.ResourceBundle;
@@ -33,7 +35,7 @@ public final class DemoModel {
      */
     private ResourceBundle rbDE = ResourceBundle.getBundle("demo-locale", new Locale("de", "CH"));
     private ResourceBundle rbEN = ResourceBundle.getBundle("demo-locale", new Locale("en", "UK"));
-
+    private final BooleanProperty visibility = new SimpleBooleanProperty(true);
     /**
      * The default locale is English, thus the {@code ResourceBundleService} is
      * initialised with it.
@@ -60,99 +62,102 @@ public final class DemoModel {
      */
     private void createForm() {
         formInstance = Form.of(
-                Group.of(
-                        Field.ofStringType(country.nameProperty())
-                                .label("country_label")
-                                .placeholder("country_placeholder")
-                                .required("required_error_message")
-                                .validate(StringLengthValidator.atLeast(2, "country_error_message")),
-                        Field.ofStringType(country.isoProperty())
-                                .label("ISO_3166_label")
-                                .placeholder("ISO_3166_placeholder")
-                                .required("required_error_message")
-                                .validate(StringLengthValidator.exactly(2, "ISO_3166_error_message")),
-                        Field.ofBooleanType(country.independenceProperty())
-                                .label("independent_label")
-                                .required("required_error_message"),
-                        Field.ofDate(country.getIndependenceDay())
-                                .label("independent_since_label")
-                                .required("required_error_message")
-                                .placeholder("independent_since_placeholder")
-                ),
-                Section.of(
-                        Field.ofStringType(country.currencyShortProperty())
-                                .label("currency_label")
-                                .placeholder("currency_placeholder")
-                                .validate(StringLengthValidator.exactly(3, "currency_error_message"))
-                                .span(ColSpan.HALF),
-                        Field.ofStringType(country.currencyLongProperty())
-                                .label("currency_long_label")
-                                .placeholder("currency_long_placeholder")
-                                .span(ColSpan.HALF),
-                        Field.ofDoubleType(country.areaProperty())
-                                .label("area_label")
-                                .format("format_error_message")
-                                .placeholder("area_placeholder")
-                                .validate(DoubleRangeValidator.atLeast(1, "area_error_message"))
-                                .span(ColSpan.HALF),
-                        Field.ofStringType(country.tldProperty())
-                                .label("internet_TLD_label")
-                                .placeholder("internet_TLD_placeholder")
-                                .span(ColSpan.HALF)
-                                .validate(
-                                        StringLengthValidator.exactly(3, "internet_TLD_error_message"),
-                                        RegexValidator.forPattern("^.[a-z]{2}$", "internet_TLD_format_error_message")
-                                ),
-                        Field.ofStringType(country.dateFormatProperty())
-                                .label("date_format_label")
-                                .placeholder("date_format_placeholder")
-                                .multiline(true)
-                                .span(ColSpan.HALF)
-                                .validate(StringLengthValidator.atLeast(8, "date_format_error_message")),
-                        Field.ofSingleSelectionType(country.allSidesProperty(), country.driverSideProperty())
-                                .required("required_error_message")
-                                .label("driving_label")
-                                .span(ColSpan.HALF)
-                                .render(() -> new SimpleRadioButtonControl<>()),
-                        Field.ofStringType(country.timeZoneProperty())
-                                .label("time_zone_label")
-                                .placeholder("time_zone_placeholder")
-                                .span(ColSpan.HALF)
-                                .validate(StringLengthValidator.exactly(3, "time_zone_error_message")),
-                        Field.ofStringType(country.summerTimeZoneProperty())
-                                .label("summer_time_zone_label")
-                                .placeholder("summer_time_zone_placeholder")
-                                .span(ColSpan.HALF)
-                                .validate(StringLengthValidator.atLeast(3, "summer_time_zone_error_message"))
-                ).title("other_information_label"),
-                Section.of(
-                        Field.ofSingleSelectionType(country.allCapitalsProperty(), country.capitalProperty())
-                                .label("capital_label")
-                                .required("required_error_message")
-                                .tooltip("capital_tooltip")
-                                .span(ColSpan.HALF),
-                        Field.ofIntegerType(country.populationProperty())
-                                .label("population_label")
-                                .format("format_error_message")
-                                .placeholder("population_placeholder")
-                                .required("required_error_message")
-                                .span(ColSpan.HALF)
-                                .validate(IntegerRangeValidator.atLeast(1, "population_error_message")),
-                        Field.ofMultiSelectionType(country.allContinentsProperty(), country.continentsProperty())
-                                .label("continent_label")
-                                .required("required_error_message")
-                                .span(ColSpan.HALF)
-                                .render(() -> new SimpleCheckBoxControl<>()),
-                        Field.ofMultiSelectionType(country.allCitiesProperty(), country.germanCitiesProperty())
-                                .label("german_cities_label")
-                                .span(ColSpan.HALF),
-                        Field.ofPasswordType("secret")
-                                .label("secret_label")
-                                .required("required_error_message")
-                                .span(ColSpan.HALF)
-                                .validate(StringLengthValidator.between(1, 10, "secret_error_message"))
-                ).title("cities_and_population_label")
-        ).title("form_label")
+                        Group.of(
+                                Field.ofStringType(country.nameProperty())
+                                        .label("country_label")
+                                        .placeholder("country_placeholder")
+                                        .required("required_error_message")
+                                        .validate(StringLengthValidator.atLeast(2, "country_error_message")),
+                                Field.ofStringType(country.isoProperty())
+                                        .label("ISO_3166_label")
+                                        .placeholder("ISO_3166_placeholder")
+                                        .required("required_error_message")
+                                        .validate(StringLengthValidator.exactly(2, "ISO_3166_error_message")),
+                                Field.ofBooleanType(country.independenceProperty())
+                                        .label("independent_label")
+                                        .required("required_error_message"),
+                                Field.ofDate(country.getIndependenceDay())
+                                        .label("independent_since_label")
+                                        .required("required_error_message")
+                                        .placeholder("independent_since_placeholder")
+                        ),
+                        Section.of(
+                                Field.ofStringType(country.currencyShortProperty())
+                                        .label("currency_label")
+                                        .placeholder("currency_placeholder")
+                                        .validate(StringLengthValidator.exactly(3, "currency_error_message"))
+                                        .span(ColSpan.HALF),
+                                Field.ofStringType(country.currencyLongProperty())
+                                        .label("currency_long_label")
+                                        .placeholder("currency_long_placeholder")
+                                        .span(ColSpan.HALF),
+                                Field.ofDoubleType(country.areaProperty())
+                                        .label("area_label")
+                                        .format("format_error_message")
+                                        .placeholder("area_placeholder")
+                                        .validate(DoubleRangeValidator.atLeast(1, "area_error_message"))
+                                        .span(ColSpan.HALF),
+                                Field.ofStringType(country.tldProperty())
+                                        .label("internet_TLD_label")
+                                        .placeholder("internet_TLD_placeholder")
+                                        .span(ColSpan.HALF)
+                                        .validate(
+                                                StringLengthValidator.exactly(3, "internet_TLD_error_message"),
+                                                RegexValidator.forPattern("^.[a-z]{2}$", "internet_TLD_format_error_message")
+                                        ),
+                                Field.ofStringType(country.dateFormatProperty())
+                                        .label("date_format_label")
+                                        .placeholder("date_format_placeholder")
+                                        .multiline(true)
+                                        .span(ColSpan.HALF)
+                                        .validate(StringLengthValidator.atLeast(8, "date_format_error_message")),
+                                Field.ofSingleSelectionType(country.allSidesProperty(), country.driverSideProperty())
+                                        .required("required_error_message")
+                                        .label("driving_label")
+                                        .span(ColSpan.HALF)
+                                        .render(SimpleRadioButtonControl::new),
+                                Field.ofStringType(country.timeZoneProperty())
+                                        .label("time_zone_label")
+                                        .placeholder("time_zone_placeholder")
+                                        .span(ColSpan.HALF)
+                                        .validate(StringLengthValidator.exactly(3, "time_zone_error_message")),
+                                Field.ofStringType(country.summerTimeZoneProperty())
+                                        .label("summer_time_zone_label")
+                                        .placeholder("summer_time_zone_placeholder")
+                                        .span(ColSpan.HALF)
+                                        .validate(StringLengthValidator.atLeast(3, "summer_time_zone_error_message"))
+                        ).title("other_information_label"),
+                        Section.of(
+                                Field.ofSingleSelectionType(country.allCapitalsProperty(), country.capitalProperty())
+                                        .label("capital_label")
+                                        .required("required_error_message")
+                                        .tooltip("capital_tooltip")
+                                        .span(ColSpan.HALF),
+                                Field.ofIntegerType(country.populationProperty())
+                                        .label("population_label")
+                                        .format("format_error_message")
+                                        .placeholder("population_placeholder")
+                                        .required("required_error_message")
+                                        .span(ColSpan.HALF)
+                                        .validate(IntegerRangeValidator.atLeast(1, "population_error_message")),
+                                Field.ofMultiSelectionType(country.allContinentsProperty(), country.continentsProperty())
+                                        .label("continent_label")
+                                        .required("required_error_message")
+                                        .span(ColSpan.HALF)
+                                        .render(SimpleCheckBoxControl::new),
+                                Field.ofMultiSelectionType(country.allCitiesProperty(), country.germanCitiesProperty())
+                                        .label("german_cities_label")
+                                        .required("selection_required")
+                                        .visibility(visibility)
+                                        .span(ColSpan.HALF),
+                                Field.ofPasswordType("secret")
+                                        .label("secret_label")
+                                        .required("required_error_message")
+                                        .span(ColSpan.HALF)
+                                        .visibility(visibility)
+                                        .validate(StringLengthValidator.between(1, 10, "secret_error_message"))
+                        ).title("cities_and_population_label")
+                ).title("form_label")
                 .i18n(rbs);
 
     }
@@ -179,4 +184,7 @@ public final class DemoModel {
         return country;
     }
 
+    public BooleanProperty visibilityProperty() {
+        return visibility;
+    }
 }

--- a/formsfx-demo/src/main/java/com/dlsc/formsfx/demo/view/RootPane.java
+++ b/formsfx-demo/src/main/java/com/dlsc/formsfx/demo/view/RootPane.java
@@ -6,6 +6,7 @@ import com.dlsc.formsfx.model.structure.Section;
 import com.dlsc.formsfx.view.renderer.FormRenderer;
 import com.dlsc.formsfx.view.util.ViewMixin;
 
+import javafx.beans.binding.Bindings;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.geometry.Insets;
@@ -131,10 +132,11 @@ public class RootPane extends BorderPane implements ViewMixin {
      */
     @Override
     public void setupBindings() {
+        validLabel.textProperty().bind(Bindings.format("Form is %s valid", Bindings.when(model.getFormInstance().validProperty()).then("").otherwise("not")));
         save.disableProperty().bind(model.getFormInstance().persistableProperty().not());
         reset.disableProperty().bind(model.getFormInstance().changedProperty().not());
         displayForm.prefWidthProperty().bind(scrollContent.prefWidthProperty());
-        model.getFormInstance().getFields().get(2).visibleProperty().bind(visibilityToggle);
+        model.visibilityProperty().bind(visibilityToggle);
     }
 
     /**
@@ -145,11 +147,8 @@ public class RootPane extends BorderPane implements ViewMixin {
     public void setupValueChangedListeners() {
         model.getFormInstance().changedProperty().addListener((observable, oldValue, newValue) -> changedLabel
                 .setText("The form has " + (newValue ? "" : "not ") + "changed."));
-        model.getFormInstance().validProperty().addListener((observable, oldValue, newValue) -> validLabel
-                .setText("The form is " + (newValue ? "" : "not ") + "valid."));
         model.getFormInstance().persistableProperty().addListener((observable, oldValue, newValue) -> persistableLabel
                 .setText("The form is " + (newValue ? "" : "not ") + "persistable."));
-
         model.getCountry().nameProperty()
                 .addListener((observable, oldValue, newValue) -> countryLabel.setText("Country: " + newValue));
         model.getCountry().currencyShortProperty()
@@ -189,11 +188,10 @@ public class RootPane extends BorderPane implements ViewMixin {
 
         visibilityToggleButton.setOnAction(event -> {
             visibilityToggle.set(!visibilityToggle.get());
-            System.out.println("visibilityToggle = " + visibilityToggle.get());
         });
     }
 
-    /**
+    /**visibilityProperty
      * This method is used to layout the nodes and regions properly.
      */
     @Override

--- a/formsfx-demo/src/main/java/com/dlsc/formsfx/demo/view/RootPane.java
+++ b/formsfx-demo/src/main/java/com/dlsc/formsfx/demo/view/RootPane.java
@@ -1,9 +1,13 @@
 package com.dlsc.formsfx.demo.view;
 
 import com.dlsc.formsfx.demo.model.DemoModel;
+import com.dlsc.formsfx.model.structure.MultiSelectionField;
 import com.dlsc.formsfx.model.structure.Section;
 import com.dlsc.formsfx.view.renderer.FormRenderer;
 import com.dlsc.formsfx.view.util.ViewMixin;
+
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.geometry.Insets;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
@@ -54,15 +58,16 @@ public class RootPane extends BorderPane implements ViewMixin {
 
     private Button editableToggle;
     private Button sectionToggle;
+    private Button visibilityToggleButton;
 
     private DemoModel model;
     private FormRenderer displayForm;
+    private final BooleanProperty visibilityToggle = new SimpleBooleanProperty(true);
 
     /**
      * The constructor to create the nodes and regions.
      *
-     * @param model
-     *          The model that holds the data.
+     * @param model The model that holds the data.
      */
     public RootPane(DemoModel model) {
         this.model = model;
@@ -103,6 +108,8 @@ public class RootPane extends BorderPane implements ViewMixin {
 
         editableToggle = new Button("Toggle Editable");
         sectionToggle = new Button("Toggle Sections");
+        visibilityToggleButton = new Button("Toggle Visibility");
+        visibilityToggleButton.getStyleClass().add("toggle-button");
         editableToggle.getStyleClass().add("toggle-button");
         sectionToggle.getStyleClass().add("toggle-button");
 
@@ -127,6 +134,7 @@ public class RootPane extends BorderPane implements ViewMixin {
         save.disableProperty().bind(model.getFormInstance().persistableProperty().not());
         reset.disableProperty().bind(model.getFormInstance().changedProperty().not());
         displayForm.prefWidthProperty().bind(scrollContent.prefWidthProperty());
+        model.getFormInstance().getFields().get(2).visibleProperty().bind(visibilityToggle);
     }
 
     /**
@@ -135,13 +143,19 @@ public class RootPane extends BorderPane implements ViewMixin {
      */
     @Override
     public void setupValueChangedListeners() {
-        model.getFormInstance().changedProperty().addListener((observable, oldValue, newValue) -> changedLabel.setText("The form has " + (newValue ? "" : "not ") + "changed."));
-        model.getFormInstance().validProperty().addListener((observable, oldValue, newValue) -> validLabel.setText("The form is " + (newValue ? "" : "not ") + "valid."));
-        model.getFormInstance().persistableProperty().addListener((observable, oldValue, newValue) -> persistableLabel.setText("The form is " + (newValue ? "" : "not ") + "persistable."));
+        model.getFormInstance().changedProperty().addListener((observable, oldValue, newValue) -> changedLabel
+                .setText("The form has " + (newValue ? "" : "not ") + "changed."));
+        model.getFormInstance().validProperty().addListener((observable, oldValue, newValue) -> validLabel
+                .setText("The form is " + (newValue ? "" : "not ") + "valid."));
+        model.getFormInstance().persistableProperty().addListener((observable, oldValue, newValue) -> persistableLabel
+                .setText("The form is " + (newValue ? "" : "not ") + "persistable."));
 
-        model.getCountry().nameProperty().addListener((observable, oldValue, newValue) -> countryLabel.setText("Country: " + newValue));
-        model.getCountry().currencyShortProperty().addListener((observable, oldValue, newValue) -> currencyLabel.setText("Currency: " + newValue));
-        model.getCountry().populationProperty().addListener((observable, oldValue, newValue) -> populationLabel.setText("Population: " + newValue));
+        model.getCountry().nameProperty()
+                .addListener((observable, oldValue, newValue) -> countryLabel.setText("Country: " + newValue));
+        model.getCountry().currencyShortProperty()
+                .addListener((observable, oldValue, newValue) -> currencyLabel.setText("Currency: " + newValue));
+        model.getCountry().populationProperty()
+                .addListener((observable, oldValue, newValue) -> populationLabel.setText("Population: " + newValue));
     }
 
     /**
@@ -164,12 +178,19 @@ public class RootPane extends BorderPane implements ViewMixin {
             languageDE.setDisable(false);
         });
 
-        sectionToggle.setOnAction(event -> model.getFormInstance().getGroups().stream().filter(s -> s instanceof Section).forEach(s -> {
-            Section sec = (Section) s;
-            sec.collapse(!sec.isCollapsed());
-        }));
-        
-        editableToggle.setOnAction(event -> model.getFormInstance().getFields().forEach(s -> s.editable(!s.isEditable())));
+        sectionToggle.setOnAction(
+                event -> model.getFormInstance().getGroups().stream().filter(s -> s instanceof Section).forEach(s -> {
+                    Section sec = (Section) s;
+                    sec.collapse(!sec.isCollapsed());
+                }));
+
+        editableToggle
+                .setOnAction(event -> model.getFormInstance().getFields().forEach(s -> s.editable(!s.isEditable())));
+
+        visibilityToggleButton.setOnAction(event -> {
+            visibilityToggle.set(!visibilityToggle.get());
+            System.out.println("visibilityToggle = " + visibilityToggle.get());
+        });
     }
 
     /**
@@ -224,7 +245,7 @@ public class RootPane extends BorderPane implements ViewMixin {
         HBox.setHgrow(editableToggle, Priority.ALWAYS);
         HBox.setHgrow(sectionToggle, Priority.ALWAYS);
         toggleContent.setPadding(new Insets(10));
-        toggleContent.getChildren().addAll(editableToggle, sectionToggle);
+        toggleContent.getChildren().addAll(editableToggle, sectionToggle, visibilityToggleButton);
         toggleContent.setSpacing(10);
         toggleContent.setPrefWidth(200);
         toggleContent.getStyleClass().add("bordered");

--- a/formsfx-demo/src/main/resources/demo-locale_de_CH.properties
+++ b/formsfx-demo/src/main/resources/demo-locale_de_CH.properties
@@ -46,3 +46,4 @@ ISO_3166_error_message = ISO 3166 code muss genau 2 Zeichen lang sein
 secret_error_message = Passwortl\u00e4nge muss zwischen 1 und 10 Zeichen sein
 
 capital_tooltip = Die Hauptstadt des Landes ist oftmals nicht die gr\u00f6sste Stadt.
+selection_required=Eine Auswahl ist erforderlich.

--- a/formsfx-demo/src/main/resources/demo-locale_en_UK.properties
+++ b/formsfx-demo/src/main/resources/demo-locale_en_UK.properties
@@ -27,12 +27,13 @@ area_placeholder = Area of country
 internet_TLD_placeholder = Internet domain of country
 date_format_placeholder = Date format of country
 time_zone_placeholder = Time zone of country
-summer_time_zone_placeholder = Summer time zone of country
+summer_time_zone_placeholder = Summer zone of country
 country_placeholder = Name of country
 ISO_3166_placeholder = ISO 3166 code of country
 
 format_error_message = Not a valid input for this field
 required_error_message = Field must not be empty
+selection_required = A selection is required
 population_error_message = Population has to be larger than 1
 currency_error_message = Currency code has to be exactly 3 characters long
 area_error_message = Area has to be larger than 1


### PR DESCRIPTION
In this pull request, I added a `BooleanProperty` to the `Element` class which controls a field's visibility when rendered.

When invisible, the field is always valid, and never gets recorded as changed (i.e `changed` property is always false)

This feature is useful in cases where fields need to be toggled in or out of the form based on an `ObservableBooleanValue`.